### PR TITLE
Genlock changes and bug fixes

### DIFF
--- a/src/osd.c
+++ b/src/osd.c
@@ -114,9 +114,9 @@ static param_t features[] = {
    {   F_SCANLINES,       "Scanlines", 0,                    1, 1 },
    {         F_ELK,             "Elk", 0,                    1, 1 },
    {         F_MUX,       "Input Mux", 0,                    1, 1 },
-   {       F_VSYNC, "VSink Indicator", 0,                    1, 1 },
+   {       F_VSYNC, "VSync Indicator", 0,                    1, 1 },
    {   F_VLOCKMODE,      "VLock Mode", 0,                    5, 1 },
-   {   F_VLOCKLINE,      "VLock Line", 1,                  270, 1 },
+   {   F_VLOCKLINE,      "VLock Line", 5,                  265, 1 },
 #ifdef MULTI_BUFFER
    {    F_NBUFFERS,     "Num Buffers", 0,                    3, 1 },
 #endif

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -12,7 +12,7 @@
 .global sw2counter
 .global sw3counter
 .global vsync_line
-
+.global default_vsync_line
 
 // ======================================================================
 // Macros
@@ -224,7 +224,9 @@ skip_swap:
 frame:
 
         bl     wait_for_vsync
-
+        ldr    r0, default_vsync_line    
+        str    r0, vsync_line      // default for vsync line if vsync in blanking area
+        
         // Working registers while frame is being captured
         //
         //  r0 = scratch register
@@ -678,5 +680,8 @@ param_capture_line:
 linecountmod10:
         .word 0
 
+default_vsync_line:
+        .word 0
+        
 vsync_line:
         .word 0

--- a/src/rgb_to_fb.h
+++ b/src/rgb_to_fb.h
@@ -27,6 +27,8 @@ extern int capture_line_mode7_4bpp();
 
 extern int vsync_line;
 
+extern int default_vsync_line;
+
 void recalculate_hdmi_clock_line_locked_update();
 
 #endif

--- a/src/rgb_to_hdmi.c
+++ b/src/rgb_to_hdmi.c
@@ -488,9 +488,9 @@ void recalculate_hdmi_clock_line_locked_update() {
         if (abs(difference) > capinfo->height/4) {
            difference = -difference;
         }
-        if (genlocked == 1 && abs(difference) > 3) {
+        if (genlocked == 1 && abs(difference) > 2) {
             genlocked = 0;
-            if (abs(difference) > 4)
+            if (abs(difference) > 3)
             {
                 log_info("Probable mode change - resetting ReSync counter");
                 resync_count = 0;

--- a/src/scripts/cmdline.txt
+++ b/src/scripts/cmdline.txt
@@ -106,11 +106,12 @@
 #
 # deinterlace: algorithm used for mode 7 deinterlacing
 #     - 0 is None
-#     - 1 is Simple Motion adaptive 1
-#     - 2 is Simple Motion adaptive 2
-#     - 3 is Simple Motion adaptive 3
-#     - 4 is Simple Motion adaptive 4
-#     - 5 is Advanced Motion adaptive (needs CPLDv2)
+#     - 1 is Simple Bob
+#     - 2 is Simple Motion adaptive 1
+#     - 3 is Simple Motion adaptive 2
+#     - 4 is Simple Motion adaptive 3
+#     - 5 is Simple Motion adaptive 4
+#     - 6 is Advanced Motion adaptive (needs CPLDv2)
 #
 # scalines: show visible scanlines in modes 0..6
 #     - 0 is scanlines off
@@ -140,7 +141,7 @@
 #  When the HDMI clock is slow the vsync indicator moves down.
 #
 # vlockline: sets the target vsync line when vlockmode is set to 3 - Locked (Exact)
-#     - range is currently 1 to 270, with 1 being right at the bottom
+#     - range is currently 5 to 270, with 5 being right at the bottom
 #
 # nbuffers: controls how many buffers are used in Mode 0..6
 #     - 0 = single buffered (this will tear and will mess up the OSD)
@@ -175,7 +176,7 @@
 # Important: All the properties must be on a single line, and no blank lines!
 #
 # Here's a good default for a Beeb or Master
-sampling06=3 sampling7=0,2,2,2,2,2,2,0,8,5 info=1 palette=0 deinterlace=5 scanlines=0 mux=0 elk=0 vsync=0 vlockmode=0 vlockline=1 nbuffers=2 debug=0 m7disable=0 keymap=123233 return=1
+sampling06=3 sampling7=0,2,2,2,2,2,2,0,8,5 info=1 palette=0 deinterlace=6 scanlines=0 mux=0 elk=0 vsync=0 vlockmode=0 vlockline=5 nbuffers=2 debug=0 m7disable=0 keymap=123233 return=1
 #
 # Here's a example showing no oversampling in Mode 0..6
 # sampling06=0,4,4,4,4,4,4,0,2 geometry06=37,28,80,256,640,512 info=1 palette=0 deinterlace=1 scanlines=0 mux=0 elk=0 vsync=0 vlockmode=0 nbuffers=2 debug=1 m7disable=0


### PR DESCRIPTION
I've made some changes and bug fixes to the genlock introducing some hysteresis and also restricted the range to 5 - 265 to allow that to work properly. (The single buffer OSD only starts to disappear around 20-25 so that shouldn't be an issue)
I also changed cmdline.txt to accomodate the above and add bob deinterlace.
Note I have changed the hdmi clock logging to log_debug as this was causing frame drops whenever there was a resync although I have also added some extra logging to see how frequent the resyncs are happening which may still cause frame drops.
It may be better in the long term to pre-calculate the hdmi pll values and maybe re-implement 'recalculate_hdmi_clock_line_locked_update()' in assembler using those values to eliminate any chance of field drops during a resync.