### PR TITLE
Genlock update

### DIFF
--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -13,6 +13,7 @@
 .global sw3counter
 .global vsync_line
 .global default_vsync_line
+.global lock_fail
 
 // ======================================================================
 // Macros

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -13,6 +13,7 @@
 .global sw3counter
 .global vsync_line
 .global default_vsync_line
+.global lock_fail
 
 // ======================================================================
 // Macros
@@ -456,10 +457,13 @@ skip_osd_update:
         // Flip to it on next V SYNC
         FLIP_BUFFER
 #endif
-
         push   {r0-r12, lr}
         bl     recalculate_hdmi_clock_line_locked_update
         pop    {r0-r12, lr}
+        
+        ldr    r0, lock_fail
+        cmp    r0,#0
+        bne    lock_failed
 
         // Loop back if required number of fields has not been reached
         // or if negative (capture forever)
@@ -470,6 +474,7 @@ skip_osd_update:
         str    r5, param_ncapture
         bne    frame
 
+lock_failed:    
         // Setup the response code
         mov    r0, r3
         and    r0, #BIT_MODE7
@@ -685,3 +690,6 @@ default_vsync_line:
         
 vsync_line:
         .word 0
+        
+lock_fail:
+        .word 0       

--- a/src/rgb_to_fb.h
+++ b/src/rgb_to_fb.h
@@ -29,6 +29,8 @@ extern int vsync_line;
 
 extern int default_vsync_line;
 
+extern int lock_fail;
+
 void recalculate_hdmi_clock_line_locked_update();
 
 #endif


### PR DESCRIPTION
I've made some minor updates to the genlock code:
1. add bias to the lock target (if the bar moves upward to lose lock then the target is one line below normal and vice-versa). This makes the lock last longer before a resync.
2. If lock lost due to a mode change then rgb_to_fb is exited to force a clock recalibration

This includes a manual merge due to conflicts with your recent change so please check.
