### PR TITLE
Integrate six bit sampling support (and other related work)

### DIFF
--- a/src/capture_line_half_4bpp_8bpp.S
+++ b/src/capture_line_half_4bpp_8bpp.S
@@ -23,153 +23,152 @@
         b       preload_capture_line_half_4bpp
 capture_line_half_4bpp:
         push    {lr}
-        cmp     r1, #400/8               //sanity check on buffer size as only capturing half of pixels so width >400 will never finish   
-        movgt   r1, r1, lsr#1
-        cmp     r5, #DUPLICATE_HEIGHT
-        orrle   r3, r3, #BITDUP_NO_LINE_DOUBLE
-        bicgt   r3, r3, #BITDUP_NO_LINE_DOUBLE 
-        SKIP_PSYNC
-capture_half_4bpp:                          
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_LOW_BITS                 // input in r8, result in r10, corrupts r9
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_HIGH_BITS                // input in r8, result in r9/r10
-        mov     r11, r10                 // save first word
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_LOW_BITS                 // input in r8, result in r10, corrupts r9
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_HIGH_BITS                // input in r8, result in r9/r10
-        
-        tst    r3, #BIT_EVEN_SAMPLES
-        andne  r9, r11, #0x00000007 
-        movne  r12, r9, lsl#4
-        andne  r9, r11, #0x00000700  
-        orrne  r12, r12, r9, lsr #8
-        andne  r9, r11, #0x00070000 
-        orrne  r12, r12, r9, lsr #4
-        andne  r9, r11, #0x07000000 
-        orrne  r12, r12, r9, lsr #16             
-
-        andne  r9, r10, #0x00000007 
-        orrne  r12, r12, r9, lsl#20
-        andne  r9, r10, #0x00000700  
-        orrne  r12, r12, r9, lsl #8
-        andne  r9, r10, #0x00070000 
-        orrne  r12, r12, r9, lsl #12
-        andne  r9, r10, #0x07000000 
-        orrne  r10, r12, r9      
-       
-        tst    r3, #BIT_ODD_SAMPLES
-        andne  r9, r11, #0x00000070 
-        movne  r12, r9
-        andne  r9, r11, #0x00007000  
-        orrne  r12, r12, r9, lsr #12
-        andne  r9, r11, #0x00700000 
-        orrne  r12, r12, r9, lsr #8
-        andne  r9, r11, #0x70000000 
-        orrne  r12, r12, r9, lsr #20             
-
-        andne  r9, r10, #0x00000070 
-        orrne  r12, r12, r9, lsl#16
-        andne  r9, r10, #0x00007000  
-        orrne  r12, r12, r9, lsl #4
-        andne  r9, r10, #0x00700000 
-        orrne  r12, r12, r9, lsl #8
-        andne  r9, r10, #0x70000000 
-        orrne  r10, r12, r9, lsr #4      
-               
-        WRITE_WORD
- 
-        subs    r1, r1, #1
-        bne     capture_half_4bpp
-        pop     {pc}       
-        
-preload_capture_line_half_4bpp:                
-        SETUP_DUMMY_PARAMETERS
-        b       capture_line_half_4bpp
-        
-        .ltorg
-       
-        // *** 8 bit ***
-        
-        
-        b       preload_capture_line_half_8bpp 
-capture_line_half_8bpp:        
-        push    {lr}
-        cmp     r1, #400/8               //sanity check on buffer size as only capturing half of pixels so width >400 will never finish   
+        cmp     r1, #400/8               //sanity check on buffer size as only capturing half of pixels so width >400 will never finish
         movgt   r1, r1, lsr#1
         cmp     r5, #DUPLICATE_HEIGHT
         orrle   r3, r3, #BITDUP_NO_LINE_DOUBLE
         bicgt   r3, r3, #BITDUP_NO_LINE_DOUBLE
-        SKIP_PSYNC   
-capture_half_8bpp:                         
+        SKIP_PSYNC
+capture_half_4bpp:
         WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_BITS_8BPP                // input in r8, result in r10, corrupts r9
+        CAPTURE_LOW_BITS                 // input in r8, result in r10, corrupts r9
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_HIGH_BITS                // input in r8, result in r9/r10
         mov     r11, r10                 // save first word
         WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_BITS_8BPP                // input in r8, result in r9/r10
+        CAPTURE_LOW_BITS                 // input in r8, result in r10, corrupts r9
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_HIGH_BITS                // input in r8, result in r9/r10
 
         tst    r3, #BIT_EVEN_SAMPLES
-        andne  r9, r11, #0x00000700 
-        movne  r12, r9, lsr#8
-        andne  r9, r11, #0x07000000  
-        orrne  r12, r12, r9, lsr #16
-        andne  r9, r10, #0x00000700 
-        orrne  r12, r12, r9, lsl#8
-        andne  r9, r10, #0x07000000  
-        orrne  r7, r12, r9
-                   
-        tst    r3, #BIT_ODD_SAMPLES
-        andne  r9, r11, #0x00000007 
-        movne  r12, r9
-        andne  r9, r11, #0x00070000  
+        andne  r9, r11, #0x00000007
+        movne  r12, r9, lsl#4
+        andne  r9, r11, #0x00000700
         orrne  r12, r12, r9, lsr #8
-        andne  r9, r10, #0x00000007 
-        orrne  r12, r12, r9, lsl#16
-        andne  r9, r10, #0x00070000  
-        orrne  r7, r12, r9, lsl #8
-             
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_BITS_8BPP                // input in r8, result in r10, corrupts r9
-        mov     r11, r10                 // save first word
-        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
-        CAPTURE_BITS_8BPP                // input in r8, result in r9/r10
-
-        tst    r3, #BIT_EVEN_SAMPLES
-        andne  r9, r11, #0x00000700 
-        movne  r12, r9, lsr#8
-        andne  r9, r11, #0x07000000  
+        andne  r9, r11, #0x00070000
+        orrne  r12, r12, r9, lsr #4
+        andne  r9, r11, #0x07000000
         orrne  r12, r12, r9, lsr #16
-        andne  r9, r10, #0x00000700 
-        orrne  r12, r12, r9, lsl#8
-        andne  r9, r10, #0x07000000  
+
+        andne  r9, r10, #0x00000007
+        orrne  r12, r12, r9, lsl#20
+        andne  r9, r10, #0x00000700
+        orrne  r12, r12, r9, lsl #8
+        andne  r9, r10, #0x00070000
+        orrne  r12, r12, r9, lsl #12
+        andne  r9, r10, #0x07000000
         orrne  r10, r12, r9
-                   
+
         tst    r3, #BIT_ODD_SAMPLES
-        andne  r9, r11, #0x00000007 
+        andne  r9, r11, #0x00000070
         movne  r12, r9
-        andne  r9, r11, #0x00070000  
+        andne  r9, r11, #0x00007000
+        orrne  r12, r12, r9, lsr #12
+        andne  r9, r11, #0x00700000
         orrne  r12, r12, r9, lsr #8
-        andne  r9, r10, #0x00000007 
+        andne  r9, r11, #0x70000000
+        orrne  r12, r12, r9, lsr #20
+
+        andne  r9, r10, #0x00000070
         orrne  r12, r12, r9, lsl#16
-        andne  r9, r10, #0x00070000  
+        andne  r9, r10, #0x00007000
+        orrne  r12, r12, r9, lsl #4
+        andne  r9, r10, #0x00700000
+        orrne  r12, r12, r9, lsl #8
+        andne  r9, r10, #0x70000000
+        orrne  r10, r12, r9, lsr #4
+
+        WRITE_WORD
+
+        subs    r1, r1, #1
+        bne     capture_half_4bpp
+        pop     {pc}
+
+preload_capture_line_half_4bpp:
+        SETUP_DUMMY_PARAMETERS
+        b       capture_line_half_4bpp
+
+        .ltorg
+
+        // *** 8 bit ***
+
+
+        b       preload_capture_line_half_8bpp
+capture_line_half_8bpp:
+        push    {lr}
+        cmp     r1, #400/8               //sanity check on buffer size as only capturing half of pixels so width >400 will never finish
+        movgt   r1, r1, lsr#1
+        cmp     r5, #DUPLICATE_HEIGHT
+        orrle   r3, r3, #BITDUP_NO_LINE_DOUBLE
+        bicgt   r3, r3, #BITDUP_NO_LINE_DOUBLE
+        SKIP_PSYNC
+capture_half_8bpp:
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_BITS_8BPP                // input in r8, result in r10, corrupts r9
+        mov     r11, r10                 // save first word
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_BITS_8BPP                // input in r8, result in r9/r10
+
+        tst    r3, #BIT_EVEN_SAMPLES
+        andne  r9, r11, #0x00000700
+        movne  r12, r9, lsr#8
+        andne  r9, r11, #0x07000000
+        orrne  r12, r12, r9, lsr #16
+        andne  r9, r10, #0x00000700
+        orrne  r12, r12, r9, lsl#8
+        andne  r9, r10, #0x07000000
+        orrne  r7, r12, r9
+
+        tst    r3, #BIT_ODD_SAMPLES
+        andne  r9, r11, #0x00000007
+        movne  r12, r9
+        andne  r9, r11, #0x00070000
+        orrne  r12, r12, r9, lsr #8
+        andne  r9, r10, #0x00000007
+        orrne  r12, r12, r9, lsl#16
+        andne  r9, r10, #0x00070000
+        orrne  r7, r12, r9, lsl #8
+
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_BITS_8BPP                // input in r8, result in r10, corrupts r9
+        mov     r11, r10                 // save first word
+        WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8
+        CAPTURE_BITS_8BPP                // input in r8, result in r9/r10
+
+        tst    r3, #BIT_EVEN_SAMPLES
+        andne  r9, r11, #0x00000700
+        movne  r12, r9, lsr#8
+        andne  r9, r11, #0x07000000
+        orrne  r12, r12, r9, lsr #16
+        andne  r9, r10, #0x00000700
+        orrne  r12, r12, r9, lsl#8
+        andne  r9, r10, #0x07000000
+        orrne  r10, r12, r9
+
+        tst    r3, #BIT_ODD_SAMPLES
+        andne  r9, r11, #0x00000007
+        movne  r12, r9
+        andne  r9, r11, #0x00070000
+        orrne  r12, r12, r9, lsr #8
+        andne  r9, r10, #0x00000007
+        orrne  r12, r12, r9, lsl#16
+        andne  r9, r10, #0x00070000
         orrne  r10, r12, r9, lsl #8
-        
+
         mov    r9, r7
-        WRITE_WORDS_8BPP  
+        WRITE_WORDS_8BPP
         subs    r1, r1, #1
         bne     capture_half_8bpp
-        pop     {pc}            
-        
-preload_capture_line_half_8bpp:       
+        pop     {pc}
+
+preload_capture_line_half_8bpp:
         SETUP_DUMMY_PARAMETERS
         b       capture_line_half_8bpp
-        
-        
-        
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
+
+

--- a/src/capture_line_half_4bpp_8bpp.S
+++ b/src/capture_line_half_4bpp_8bpp.S
@@ -101,6 +101,7 @@ capture_line_half_8bpp:
         cmp     r5, #DUPLICATE_HEIGHT
         orrle   r3, r3, #BITDUP_NO_LINE_DOUBLE
         bicgt   r3, r3, #BITDUP_NO_LINE_DOUBLE
+        bic     r3, #MASKDUP_PALETTE_HIGH_NIBBLE
         SKIP_PSYNC
 capture_half_8bpp:
         WAIT_FOR_PSYNC_EDGE              // expects GPLEV0 in r4, result in r8

--- a/src/cpld.h
+++ b/src/cpld.h
@@ -9,6 +9,21 @@
 #define DESIGN_ALTERNATIVE  1   // This has now been removed from the code base
 #define DESIGN_ATOM         2
 
+enum {
+   // Sampling params
+   ALL_OFFSETS,
+   A_OFFSET,
+   B_OFFSET,
+   C_OFFSET,
+   D_OFFSET,
+   E_OFFSET,
+   F_OFFSET,
+   HALF,
+   DIVIDER,
+   DELAY,
+   SIXBIT
+};
+
 typedef struct {
    int key;
    const char *name;
@@ -23,7 +38,7 @@ typedef struct {
    const char *name;
    void (*init)(int cpld_version);
    int (*get_version)();
-   void (*set_mode)(capture_info_t *capinfo, int mode7, int paletteControl);
+   void (*set_mode)(capture_info_t *capinfo, int mode7);
    void (*calibrate)(capture_info_t *capinfo, int elk);
    // Support for the UI
    param_t *(*get_params)();

--- a/src/cpld_atom.c
+++ b/src/cpld_atom.c
@@ -174,13 +174,13 @@ static void cpld_calibrate(capture_info_t *capinfo, int elk) {
    log_info("Calibration complete, errors = %d", errors);
 }
 
-static void cpld_set_mode(capture_info_t *capinfo, int mode, int paletteControl) {
+static void cpld_set_mode(capture_info_t *capinfo, int mode) {
    write_config(config);
    if (capinfo) {
       if (capinfo->bpp == 8) {
-         capinfo->capture_line = capture_line_atom_8bpp;
+         capinfo->capture_line = capture_line_atom_8bpp_table;
       } else {
-         capinfo->capture_line = capture_line_atom_4bpp;
+         capinfo->capture_line = capture_line_atom_4bpp_table;
       }
    }
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -49,7 +49,7 @@
 #define OFFSET_CURR_BUFFER 14        // bit 14-15 CURR_BUFFER
 #define MASK_CURR_BUFFER (3 << OFFSET_CURR_BUFFER)
 
-#define OFFSETDUP_PALETTE_HIGH_NIBBLE 12        // bit 12-15 
+#define OFFSETDUP_PALETTE_HIGH_NIBBLE 12        // bit 12-15
 #define MASKDUP_PALETTE_HIGH_NIBBLE (15 << OFFSETDUP_PALETTE_HIGH_NIBBLE)
 
 #define BIT_INTERLACED 0x10000       // bit 16, indicates the frame is expected to be interlaced
@@ -64,13 +64,13 @@
 #define BIT_FIELD_TYPE1       0x00800000  // bit 23, indicates the field type of the previous field
 #define BIT_FIELD_TYPE1_VALID 0x01000000  // bit 24, indicates FIELD_TYPE1 is valid
 
-#define BITDUP_MODE2_16COLOUR    0x00800000  // bit 23, if set then 16 colour mode 2 is emulated by decoding mode 0 
+#define BITDUP_MODE2_16COLOUR    0x00800000  // bit 23, if set then 16 colour mode 2 is emulated by decoding mode 0
 #define BITDUP_NO_LINE_DOUBLE    0x01000000  // bit 24, if set then lines aren't duplicated in capture
 
 #define BIT_ODD_SAMPLES       0x02000000  // bit 25, if set only use odd samples
 #define BIT_EVEN_SAMPLES      0x04000000  // bit 26, if set only use even samples
 
- 
+
                                              // bits 27-31 unused
 
 // R0 return value bits
@@ -86,7 +86,7 @@
 #define BIT_MODE2_PALETTE     0x04  // bit 2, if set mode 2 palette is customised
 #define BIT_MODE7_PALETTE     0x08  // bit 3, if set mode 7 palette is customised
 #define BIT_SET_MODE2_16COLOUR   0x10  // bit 4, if set mode 2 16 colour is enabled
-#define BIT_MULTI_PALETTE        0x020   // bit 5  if set then multiple 16 colour palettes  
+#define BIT_MULTI_PALETTE        0x020   // bit 5  if set then multiple 16 colour palettes
 
 #define DUPLICATE_HEIGHT      380      // frame buffers above this height duplicate lines
 #define VERTICAL_OFFSET         6      // start of actual bbc screen from start of buffer
@@ -123,17 +123,19 @@
 #define SMICTRL  (PERIPHERAL_BASE + 0x600000)
 
 // Offsets into capture_info_t structure below
-#define O_FB_BASE         0
-#define O_FB_PITCH        4
-#define O_FB_WIDTH        8
-#define O_FB_HEIGHT      12
-#define O_FB_BPP         16
-#define O_CHARS_PER_LINE 20
-#define O_NLINES         24
-#define O_H_OFFSET       28
-#define O_V_OFFSET       32
-#define O_NCAPTURE       36
-#define O_CAPTURE_LINE   40
+#define O_FB_BASE          0
+#define O_FB_PITCH         4
+#define O_FB_WIDTH         8
+#define O_FB_HEIGHT       12
+#define O_FB_BPP          16
+#define O_CHARS_PER_LINE  20
+#define O_NLINES          24
+#define O_H_OFFSET        28
+#define O_V_OFFSET        32
+#define O_NCAPTURE        36
+#define O_PALETTE_CONTROL 40
+#define O_SAMPLE_WIDTH    44
+#define O_CAPTURE_LINE    48
 
 #else
 
@@ -148,8 +150,11 @@ typedef struct {
    int h_offset;       // horizontal offset (in psync clocks)
    int v_offset;       // vertical offset (in lines)
    int ncapture;       // number of fields to capture, or -1 to capture forever
+   int palette_control;// normal / in band data / ntsc artifacting etc
+   int sample_width;   // 3 or 6 bits
    int (*capture_line)(); // the capture line function to use
    int px_sampling;    // whether to sample normally, sub-sample or pixel double
+
 } capture_info_t;
 
 typedef struct {

--- a/src/geometry.c
+++ b/src/geometry.c
@@ -9,8 +9,7 @@ static const char *px_sampling_names[] = {
    "Even",
    "Half Odd",
    "Half Even",
-   "Double",
-   "PSYNC x2"
+   "Double"
 };
 
 static param_t params[] = {
@@ -70,7 +69,7 @@ static void update_param_range() {
 
 void geometry_init(int version) {
    // These are Beeb specific defaults so the geometry property can be ommitted
-   mode7_geometry.v_offset      =        21;
+   mode7_geometry.v_offset      =        18;
    mode7_geometry.h_width       =  504 / (32 / 4);
    mode7_geometry.v_height      =       270;
    mode7_geometry.fb_width      =       504;

--- a/src/geometry.c
+++ b/src/geometry.c
@@ -101,7 +101,7 @@ void geometry_init(int version) {
    } else {
       // For CPLDv3 onwards
       mode7_geometry.h_offset   = 32;
-      default_geometry.h_offset = 40;
+      default_geometry.h_offset = 38;
    }
    geometry_set_mode(0);
 }

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -11,7 +11,6 @@ enum {
    PS_HALF_O,    // Odd pixels are used, even pixels are ignored
    PS_HALF_E,    // Even pixels are used, odd pixels are ignored
    PS_DOUBLE,    // pixels are doubled
-   PS_SIXBITS,
    NUM_PS
 };
 

--- a/src/macros.S
+++ b/src/macros.S
@@ -33,7 +33,7 @@ wait\@:
         addgt  r7, r7, #1
         cmp    r10, #(4000 - 224)
         addgt  r7, r7, #1
-        
+
         // Skip the configured number of psync edges (modes 0..6: edges every 250ns, mode 7: edges ever 333ns)
         orr    r3, r3, #PSYNC_MASK             // first edge is a 0->1
         cmp    r7, #0
@@ -71,7 +71,7 @@ skip_psync_loop_exit\@:
         and    r9, r8, #(0x0f << PIXEL_BASE)
         and    r14, r8, #(0x0f << (PIXEL_BASE + 6))
         orr    r10, r10, r9, lsl #(20 - PIXEL_BASE)
-        orr    r10, r10, r14, lsl #(10 - PIXEL_BASE)        
+        orr    r10, r10, r14, lsl #(10 - PIXEL_BASE)
 .endm
 
 .macro CAPTURE_3_BITS_WIDE
@@ -145,7 +145,7 @@ skip_psync_loop_exit\@:
         // Pixel 3 in GPIO 13..11 -> 31..24
 
         and    r10, r8, #(7 << PIXEL_BASE)
-        and    r9, r8, #(7 << (PIXEL_BASE + 3))      
+        and    r9, r8, #(7 << (PIXEL_BASE + 3))
         mov    r10, r10, lsr #(PIXEL_BASE)
         orr    r10, r10, r9, lsl #(8 - (PIXEL_BASE + 3))
 
@@ -171,22 +171,22 @@ skip_psync_loop_exit\@:
         and    r8, r8, #(7 << (PIXEL_BASE + 9))
         orr    r10, r10, r9, lsl #(6 - PIXEL_BASE)
         orr    r10, r10, r8, lsr #(1 + PIXEL_BASE)
-         
+
         tst    r3, #BIT_EVEN_SAMPLES
-        ldrne  r9, =0x70707070 
+        ldrne  r9, =0x70707070
         bicne  r10, r10, r9
         orrne  r10, r10, r10, lsl #4
-                     
+
         tst    r3, #BIT_ODD_SAMPLES
-        ldrne  r9, =0x07070707 
+        ldrne  r9, =0x07070707
         bicne  r10, r10, r9
-        orrne  r10, r10, r10, lsr #4   
-        
+        orrne  r10, r10, r10, lsr #4
+
         mov    r6, r6, lsl #8   // mode 0 sentinel
         mov    r7, r7, lsl #2   // mode 0-6 sentinel
         mov    r14, #0          // mode 2 translation
-        
-        tst    r10, #0x00000070       
+
+        tst    r10, #0x00000070
         orrne  r14, r14, #0x08
         orrne  r6, r6, #0x80
         tst    r10, #0x00000007
@@ -216,17 +216,17 @@ skip_psync_loop_exit\@:
         and    r8, r8, #(7 << (PIXEL_BASE + 9))
         orr    r10, r10, r9, lsl #(22 - PIXEL_BASE)
         orr    r10, r10, r8, lsl #(15 - PIXEL_BASE)
-        
+
         tst    r3, #BIT_EVEN_SAMPLES
-        ldrne  r9, =0x70707070 
+        ldrne  r9, =0x70707070
         bicne  r10, r10, r9
         orrne  r10, r10, r10, lsl #4
-                     
+
         tst    r3, #BIT_ODD_SAMPLES
-        ldrne  r9, =0x07070707 
+        ldrne  r9, =0x07070707
         bicne  r10, r10, r9
-        orrne  r10, r10, r10, lsr #4   
-        
+        orrne  r10, r10, r10, lsr #4
+
         tst    r10, #0x00700000
         orrne  r14, r14, #0x02
         orrne  r6, r6, #0x08
@@ -240,11 +240,11 @@ skip_psync_loop_exit\@:
         orrne  r14, r14, #0x010000
         orrne  r6, r6, #0x01
         orrne  r7, r7, #1
-        
-        tst    r3, #BITDUP_MODE2_16COLOUR  
+
+        tst    r3, #BITDUP_MODE2_16COLOUR
         orrne  r10, r14, r14, lsl #4
-        orrne  r10, r10, r10, lsl #8   
-        
+        orrne  r10, r10, r10, lsl #8
+
 .endm
 
 .macro CAPTURE_LOW_BITS_TRANSLATE_8BPP
@@ -252,7 +252,7 @@ skip_psync_loop_exit\@:
         // Pixel 1 in GPIO  7.. 5 -> 15.. 8
         // Pixel 2 in GPIO 10.. 8 -> 23..16
         // Pixel 3 in GPIO 13..11 -> 31..24
-  
+
         and    r5, r8, #(7 << PIXEL_BASE)
         and    r9, r8, #(7 << (PIXEL_BASE + 3))
         mov    r5, r5, lsr #(PIXEL_BASE)
@@ -262,21 +262,21 @@ skip_psync_loop_exit\@:
         and    r8, r8, #(7 << (PIXEL_BASE + 9))
         orr    r5, r5, r9, lsl #(16 - (PIXEL_BASE + 6))
         orr    r5, r5, r8, lsl #(24 - (PIXEL_BASE + 9))
-        
+
         tst    r3, #BIT_EVEN_SAMPLES
-        ldrne  r9, =0x00070007 
+        ldrne  r9, =0x00070007
         bicne  r5, r5, r9
         orrne  r5, r5, r5, lsr #8
-                     
+
         tst    r3, #BIT_ODD_SAMPLES
-        ldrne  r9, =0x07000700 
+        ldrne  r9, =0x07000700
         bicne  r5, r5, r9
-        orrne  r5, r5, r5, lsl #8   
+        orrne  r5, r5, r5, lsl #8
 
         mov    r6, r6, lsl #8   // mode 0 sentinel
         mov    r7, r7, lsl #2   // mode 0-6 sentinel
         mov    r14, #0          // mode 2 translation (low byte = left pixel, high byte = right pixel
-        tst    r5, #0x00000007       
+        tst    r5, #0x00000007
         orrne  r14, r14, #0x08
         orrne  r6, r6, #0x80
         tst    r5, #0x00000700
@@ -288,7 +288,7 @@ skip_psync_loop_exit\@:
         tst    r5, #0x07000000
         orrne  r14, r14, #0x04000000
         orrne  r6, r6, #0x10
-        orrne  r7, r7, #2    
+        orrne  r7, r7, #2
 .endm
 
 .macro CAPTURE_HIGH_BITS_TRANSLATE_8BPP
@@ -306,17 +306,17 @@ skip_psync_loop_exit\@:
         and    r8, r8, #(7 << (PIXEL_BASE + 9))
         orr    r10, r10, r9, lsl #(16 - (PIXEL_BASE + 6))
         orr    r10, r10, r8, lsl #(24 - (PIXEL_BASE + 9))
-        
+
         tst    r3, #BIT_EVEN_SAMPLES
-        ldrne  r9, =0x00070007 
+        ldrne  r9, =0x00070007
         bicne  r10, r10, r9
         orrne  r10, r10, r10, lsr #8
-                     
+
         tst    r3, #BIT_ODD_SAMPLES
-        ldrne  r9, =0x07000700 
+        ldrne  r9, =0x07000700
         bicne  r10, r10, r9
-        orrne  r10, r10, r10, lsl #8       
-        
+        orrne  r10, r10, r10, lsl #8
+
         tst    r10, #0x00000007
         orrne  r14, r14, #0x02
         orrne  r6, r6, #0x08
@@ -330,15 +330,15 @@ skip_psync_loop_exit\@:
         orrne  r14, r14, #0x01000000
         orrne  r6, r6, #0x01
         orrne  r7, r7, #1
-        
+
         tst    r3, #BITDUP_MODE2_16COLOUR
         moveq  r9, r5
-        andne  r9, r14, #0xff    
+        andne  r9, r14, #0xff
         orrne  r9, r9, r9, lsl #8
         orrne  r9, r9, r9, lsl #16
-        andne  r10, r14, #0xff000000  
+        andne  r10, r14, #0xff000000
         orrne  r10, r10, r10, lsr #8
-        orrne  r10, r10, r10, lsr #16  
+        orrne  r10, r10, r10, lsr #16
 .endm
 
 
@@ -395,15 +395,15 @@ skip_psync_loop_exit\@:
 .macro WRITE_WORDS_8BPP_FAST
         eor    r9, r9, r5       //eor in vsync and debug
         eor    r10, r10, r6     //eor in vsync and debug
-        stmia  r0, {r9, r10}  
-        add    r0, r0, r2   
+        stmia  r0, {r9, r10}
+        add    r0, r0, r2
         tst    r3,  #BIT_SCANLINES
         movne  r9, #0
         movne  r10, #0
         tst    r3, #BITDUP_NO_LINE_DOUBLE
         stmeqia  r0, {r9, r10}
         subs   r0, r0, r2
-        add    r0, r0, #8 
+        add    r0, r0, #8
 .endm
 
 .macro WRITE_WORD
@@ -419,9 +419,9 @@ skip_psync_loop_exit\@:
         tst    r3,  #BITDUP_NO_LINE_DOUBLE
         streq  r10, [r0, r2]
         add    r0, r0, #4
-.endm   
-        
-.macro WRITE_WORDS_8BPP 
+.endm
+
+.macro WRITE_WORDS_8BPP
         and    r8, r3, #MASKDUP_PALETTE_HIGH_NIBBLE
         mov    r8, r8, lsr #(OFFSETDUP_PALETTE_HIGH_NIBBLE - 4)
         orr    r8, r8, r8, lsl #8
@@ -435,8 +435,8 @@ skip_psync_loop_exit\@:
         tst    r3, #BIT_DEBUG
         eorne  r9, r9, #0x05           //magenta in leftmost
         eorne  r10, r10, #0x02000000   //green in rightmost
-        stmia  r0, {r9, r10}  
-        add    r0, r0, r2   
+        stmia  r0, {r9, r10}
+        add    r0, r0, r2
         tst    r3,  #BIT_SCANLINES
         movne  r9, #0
         movne  r10, #0
@@ -444,10 +444,10 @@ skip_psync_loop_exit\@:
         stmeqia  r0, {r9, r10}
         subs   r0, r0, r2
         add    r0, r0, #8
-.endm 
-       
+.endm
+
 .macro SETUP_DUMMY_PARAMETERS
-        ldr     r0, =(dummyscreen + 1024)    //in case data written backwards       
+        ldr     r0, =(dummyscreen + 1024)    //in case data written backwards
         mov     r1, #1
         mov     r2, #0
         orr     r3, r3, #BIT_VSYNC_MARKER    // ensure that constants are in data cache
@@ -456,7 +456,7 @@ skip_psync_loop_exit\@:
         mov     r5, #(DUPLICATE_HEIGHT * 2)
         mov     r6, #0
         mov     r7, #1
-.endm         
+.endm
 
 // ======================================================================
 // Macros

--- a/src/macros.S
+++ b/src/macros.S
@@ -8,17 +8,32 @@ wait\@:
         eor    r8, r3
         tst    r8, #PSYNC_MASK
         bne    wait\@
-        // Check again in case of noise
-        ldr    r8, [r4]
-        eor    r8, r3
-        tst    r8, #PSYNC_MASK
-        bne    wait\@
+
         // toggle the polarity to look for the opposite edge next time
         eor    r8, r3
         eor    r3, #PSYNC_MASK
 .endm
 
 .macro SKIP_PSYNC
+        // Wait for the start of hsync
+        WAIT_FOR_CSYNC_0
+        READ_CYCLE_COUNTER r10
+        // Wait for the end of hsync
+        WAIT_FOR_CSYNC_1
+        READ_CYCLE_COUNTER r9
+        // Calculate length of low hsync pulse (in ARM cycles = ns)
+        sub    r10, r9, r10
+        // Start with the configured horizontal offset
+        // Implement half character horizontal scrolling:
+        // - a "short"  hsync is 3.5us, leave h_offset as-is
+        // - a "normal" hsync is 4.0us, increment h_offset by 1
+        // - a "long"   hsync is 4.5us, increment h_offset by 2
+        // So test against two thresholds inbetween these values
+        cmp    r10, #(4000 + 224)
+        addgt  r7, r7, #1
+        cmp    r10, #(4000 - 224)
+        addgt  r7, r7, #1
+        
         // Skip the configured number of psync edges (modes 0..6: edges every 250ns, mode 7: edges ever 333ns)
         orr    r3, r3, #PSYNC_MASK             // first edge is a 0->1
         cmp    r7, #0
@@ -442,3 +457,119 @@ skip_psync_loop_exit\@:
         mov     r6, #0
         mov     r7, #1
 .endm         
+
+// ======================================================================
+// Macros
+// ======================================================================
+
+// Data Synchronisation Barrier
+.macro DSB
+        mcr    p15, 0, r0, c7, c10, 4
+.endm
+
+// Data Memory Barrier
+.macro DMB
+        mcr    p15, 0, r0, c7, c10, 5
+.endm
+
+.macro READ_CYCLE_COUNTER reg
+#if defined(RPI2) || defined(RPI3)
+        mrc    p15, 0, \reg, c9, c13, 0
+#else
+        mrc    p15, 0, \reg, c15, c12, 1
+#endif
+.endm
+
+.macro CLEAR_VSYNC
+        // Clear the VSYNC interrupt
+        ldr    r0, =SMICTRL
+        bic    r3, r3, #BIT_VSYNC_MARKER
+        mov    r7, #0
+        str    r7, [r0]
+        // Don't proceed until this write is complete
+        DSB
+.endm
+
+.macro SHOW_VSYNC
+        bic    r3, r3, #BIT_VSYNC_MARKER
+        tst    r3, #(BIT_PROBE)
+        bne    novsync\@
+        // Poll for the VSYNC interrupt
+        ldr    r0, =INTPEND2
+        ldr    r0, [r0]
+        tst    r0, #(1<<VSYNCINT)
+        beq    novsync\@
+        // Clear the VSYNC interrupt
+        CLEAR_VSYNC
+        // If the vsync indicator is enabled, mark the next line in red
+        tst    r3, #(BIT_VSYNC)
+        orrne  r3, r3, #BIT_VSYNC_MARKER
+        // Remember the line where vsync occurred
+        str    r5, vsync_line
+novsync\@:
+.endm
+
+#ifdef MULTI_BUFFER
+.macro FLIP_BUFFER
+        // Skip the multi buffering in mode 7 and probe mode
+        tst    r3, #(BIT_MODE7 | BIT_PROBE)
+        bne    noflip\@
+        // Flip to the last completed draw buffer
+        // It seems the GPU delays this until the next vsync
+        push   {r0-r3}
+        mov    r14, r3, lsr #OFFSET_LAST_BUFFER
+        and    r0, r14, #3
+        bl     swapBuffer
+        pop    {r0-r3}
+noflip\@:
+.endm
+#endif
+
+.macro WAIT_FOR_CSYNC_0
+waitlo\@:
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        tst    r8, #CSYNC_MASK
+        bne    waitlo\@
+        // Check again in case of noise
+        ldr    r8, [r4]
+        tst    r8, #CSYNC_MASK
+        bne    waitlo\@
+.endm
+
+.macro WAIT_FOR_CSYNC_1
+waithi\@:
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        tst    r8, #CSYNC_MASK
+        beq    waithi\@
+        // Check again in case of noise
+        ldr    r8, [r4]
+        tst    r8, #CSYNC_MASK
+        beq    waithi\@
+.endm
+
+.macro KEY_PRESS_DETECT mask, ret, counter
+        ldr    r5, \counter    // Load the counter value
+        tst    r8, #\mask      // Is the button pressed (active low)?
+        movne  r5, #0          // Clear the counter
+        addeq  r5, r5, #1      // If pressed, then increment the counter valye
+        str    r5, \counter    // And always write back the counter value
+
+        cmp    r5, #1          // Counter goes from 0->1 when key initially
+        orreq  r0, #\ret       // Indicate the initial press in the result
+
+        cmp    r5, #32         // 32 = auto repeat delay
+        tstge  r5, #7          // 7  = auto repeat rate
+        orreq  r0, #\ret       // Indicate the auto repeated press in the result
+
+        cmp    r5, #128        // 128 = auto repeat delay
+        tstge  r5, #3          // 3 = auto repeat rate
+        orreq  r0, #\ret       // Indicate the auto repeated press in the result
+
+        cmp    r5, #256        // 256 = auto repeat delay
+        tstge  r5, #1          // 1 = auto repeat rate
+        orreq  r0, #\ret       // Indicate the auto repeated press in the result
+.endm
+
+

--- a/src/osd.c
+++ b/src/osd.c
@@ -225,7 +225,7 @@ static menu_t processing_menu = {
    {
       (base_menu_item_t *) &back_ref,
       (base_menu_item_t *) &palettecontrol_ref,
-      (base_menu_item_t *) &palette_ref,     
+      (base_menu_item_t *) &palette_ref,
       (base_menu_item_t *) &deinterlace_ref,
       (base_menu_item_t *) &scanlines_ref,
       NULL
@@ -427,7 +427,7 @@ static int get_feature(int num) {
    case F_PALETTE:
       return palette;
    case F_PALETTECONTROL:
-      return get_paletteControl();   
+      return get_paletteControl();
    case F_SCANLINES:
       return get_scanlines();
    case F_ELK:
@@ -759,22 +759,22 @@ static uint32_t palette_data[256];
 void osd_update_palette() {
    int m;
    int num_colours = (capinfo->bpp == 8) ? 256 : 16;
-   
+
    for (int i = 0; i < num_colours; i++) {
      int r = (i & 1) ? 255 : 0;
      int g = (i & 2) ? 255 : 0;
-     int b = (i & 4) ? 255 : 0; 
-       
-     if (paletteFlags & BIT_MODE2_PALETTE) { 
+     int b = (i & 4) ? 255 : 0;
+
+     if (paletteFlags & BIT_MODE2_PALETTE) {
 
         r = customPalette[i] & 0xff;
         g = (customPalette[i]>>8) & 0xff;
         b = (customPalette[i]>>16) & 0xff;
 
      } else {
-       
+
       switch (palette) {
-      case PALETTE_INVERSE: 
+      case PALETTE_INVERSE:
          r = 255 - r;
          g = 255 - g;
          b = 255 - b;
@@ -908,7 +908,7 @@ void osd_update_palette() {
       if (get_debug()) {
          palette_data[i] |= 0x00101010;
       }
-     
+
    }
 
    // Flush the previous swapBuffer() response from the GPU->ARM mailbox
@@ -937,7 +937,7 @@ void osd_set(int line, int attr, char *text) {
    int len = strlen(text);
    if (len > LINELEN) {
       len = LINELEN;
-   } 
+   }
    strncpy(buffer + line * LINELEN, text, len);
    osd_update((uint32_t *)capinfo->fb, capinfo->pitch);
 }
@@ -1063,7 +1063,7 @@ int osd_key(int key) {
                osd_state = IDLE;
             } else {
                depth--;
-               if (return_at_end == 0) 
+               if (return_at_end == 0)
                    current_item[depth] = 0;
                redraw_menu();
             }
@@ -1155,7 +1155,7 @@ void get_cmdline_props_sample_geometry(void)
             }
          }
          if (prop) {
-            cpld->set_mode(NULL, m7, get_paletteControl());
+            cpld->set_mode(NULL, m7);
             geometry_set_mode(m7);
             log_info("config.txt:  %s = %s", propname, prop);
             char *prop2 = strtok(prop, ",");
@@ -1186,7 +1186,7 @@ void get_cmdline_props_sample_geometry(void)
       }
    }
 }
-   
+
 void osd_init() {
    char *prop;
    // Precalculate character->screen mapping table
@@ -1220,7 +1220,7 @@ void osd_init() {
    // char bit  8 -> double_size_map + 0 bits 31, 27
    // ...
    // char bit 11 -> double_size_map + 0 bits  7,  3
-   
+
    for (int i = 0; i <= 0xff; i++)
    {
        unsigned char r;
@@ -1240,10 +1240,10 @@ void osd_init() {
           b = (i & 0x4)? lum : 0;
        }
        customPalette[i] = ((int)b<<16) | ((int)g<<8) | (int)r;
-       paletteHighNibble[i] = i >> 5;       
+       paletteHighNibble[i] = i >> 5;
    }
 
-   
+
    memset(normal_size_map_4bpp, 0, sizeof(normal_size_map_4bpp));
    memset(double_size_map_4bpp, 0, sizeof(double_size_map_4bpp));
    memset(normal_size_map_8bpp, 0, sizeof(normal_size_map_8bpp));
@@ -1282,15 +1282,15 @@ void osd_init() {
                double_size_map_4bpp[i * 3    ] |= 0x88 << (8 * (11 - j)); // aaaaaaaa
             }
 
-            
+
             // ======= 4 bits/pixel tables for 8x8 font======
 
             // Normal size,
-            // aaaaaaaa 
+            // aaaaaaaa
             if (j < 8) {
                normal_size_map8_4bpp[i       ] |= 0x8 << (4 * (7 - (j ^ 1)));   // aaaaaaaa
             }
-            
+
             // Double size
             // aaaaaaaa bbbbbbbb
             if (j < 4) {
@@ -1298,8 +1298,8 @@ void osd_init() {
             } else if (j < 8) {
                double_size_map8_4bpp[i * 2    ] |= 0x88 << (8 * (7 - j));  // aaaaaaaa
             }
-            
-            
+
+
             // ======= 8 bits/pixel tables ======
 
             // Normal size
@@ -1327,8 +1327,8 @@ void osd_init() {
             } else {
                double_size_map_8bpp[i * 6    ] |= 0x8080 << (16 * (11 - j)); // aaaaaaaa
             }
-            
-            
+
+
             // ======= 8 bits/pixel tables for 8x8 font======
 
             // Normal size
@@ -1337,7 +1337,7 @@ void osd_init() {
                normal_size_map8_8bpp[i * 2 + 1] |= 0x80 << (8 * (3 - j));  // bbbbbbbb
             } else if (j < 8) {
                normal_size_map8_8bpp[i * 2    ] |= 0x80 << (8 * (7 - j));  // aaaaaaaa
-            } 
+            }
 
             // Double size
             // aaaaaaaa bbbbbbbb cccccccc dddddddd
@@ -1349,8 +1349,8 @@ void osd_init() {
                double_size_map8_8bpp[i * 4 + 1] |= 0x8080 << (16 * (5 - j));  // bbbbbbbb
             } else if (j < 8) {
                double_size_map8_8bpp[i * 4    ] |= 0x8080 << (16 * (7 - j));  // aaaaaaaa
-            } 
-             
+            }
+
          }
       }
    }
@@ -1431,7 +1431,7 @@ void osd_init() {
    }
    get_cmdline_props_sample_geometry();
    get_cmdline_props_sample_geometry();  //read twice to workaround max value limiting problem in geometry
-   
+
    // Properties below this point are not updateable in the UI
    prop = get_cmdline_prop("keymap");
    if (prop) {
@@ -1494,12 +1494,12 @@ void osd_update(uint32_t *osd_base, int bytes_per_line) {
    }
   // SAA5050 character data is 12x20
   int bufferCharWidth = geometry_get_value(FB_WIDTH) / 12;         // SAA5050 character data is 12x20
-   
+
   uint32_t *line_ptr = osd_base;
   int words_per_line = bytes_per_line >> 2;
   if ((geometry_get_value(FB_HEIGHT) > DUPLICATE_HEIGHT)
        && (bufferCharWidth >= LINELEN)
-       && (geometry_get_value(FB_BPP) < 8 ) ) {       // if frame buffer is large enough and not 8bpp use SAA5050 font 
+       && (geometry_get_value(FB_BPP) < 8 ) ) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
    for (int line = 0; line < NLINES; line++) {
       int attr = attributes[line];
       int len = (attr & ATTR_DOUBLE_SIZE) ? (LINELEN >> 1) : LINELEN;
@@ -1587,9 +1587,9 @@ void osd_update(uint32_t *osd_base, int bytes_per_line) {
          }
       }
    }
-  
+
   } else {
-      // use 8x8 fonts for smaller frame buffer  
+      // use 8x8 fonts for smaller frame buffer
       for (int line = 0; line < NLINES; line++) {
       int attr = attributes[line];
       int len = (attr & ATTR_DOUBLE_SIZE) ? (LINELEN >> 1) : LINELEN;
@@ -1607,7 +1607,7 @@ void osd_update(uint32_t *osd_base, int bytes_per_line) {
             if (c == ']') {
                 c = '>';
             }
-                        
+
             // Character row is 12 pixels
                  int data = (int) fontdata8[8 * c + y];
             // Map to the screen pixel format
@@ -1663,9 +1663,9 @@ void osd_update(uint32_t *osd_base, int bytes_per_line) {
             line_ptr += words_per_line;
          }
       }
-   }  
+   }
   }
-  
+
 }
 
 // This is a stripped down version of the above that is significantly
@@ -1682,10 +1682,10 @@ void osd_update_fast(uint32_t *osd_base, int bytes_per_line) {
   }
   // SAA5050 character data is 12x20
   int bufferCharWidth = geometry_get_value(FB_WIDTH) / 12;         // SAA5050 character data is 12x20
-   
+
   uint32_t *line_ptr = osd_base;
   int words_per_line = bytes_per_line >> 2;
-   
+
   if ((geometry_get_value(FB_HEIGHT) > DUPLICATE_HEIGHT)
        && (bufferCharWidth >= LINELEN)
        && (geometry_get_value(FB_BPP) < 8 ) ) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
@@ -1767,9 +1767,9 @@ void osd_update_fast(uint32_t *osd_base, int bytes_per_line) {
          }
       }
    }
-   
+
   } else {
-      
+
      // use 8x8 fonts for smaller frame buffer
      for (int line = 0; line < NLINES; line++) {
       int attr = attributes[line];
@@ -1837,8 +1837,8 @@ void osd_update_fast(uint32_t *osd_base, int bytes_per_line) {
          } else {
             line_ptr += words_per_line;
          }
-      } 
+      }
      }
-   
-  }  
+
+  }
 }

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -20,6 +20,22 @@
 .global dummyscreen
 
 
+.global capture_line_mode7_4bpp_table
+.global capture_line_normal_4bpp_table
+.global capture_line_odd_4bpp_table
+.global capture_line_even_4bpp_table
+.global capture_line_double_4bpp_table
+.global capture_line_half_odd_4bpp_table
+.global capture_line_half_even_4bpp_table
+.global capture_line_normal_8bpp_table
+.global capture_line_odd_8bpp_table
+.global capture_line_even_8bpp_table
+.global capture_line_double_8bpp_table
+.global capture_line_half_odd_8bpp_table
+.global capture_line_half_even_8bpp_table
+.global capture_line_atom_4bpp_table
+.global capture_line_atom_8bpp_table
+
 
 rgb_to_fb:
 
@@ -46,9 +62,12 @@ rgb_to_fb:
         str    r2, param_ncapture
         ldr    r2, [r0, #O_CAPTURE_LINE]
         str    r2, param_capture_line
+        ldr    r2, [r0, #O_PALETTE_CONTROL]
+        str    r2, param_palette_control
+        ldr    r2, [r0, #O_SAMPLE_WIDTH]
+        str    r2, param_sample_width
         ldr    r2, [r0, #O_FB_BASE]
         str    r2, param_framebuffer0
-
         // Sanity check chars_per_line <= fb_width / 8
         ldr    r3, param_fb_width
         lsr    r3, r3, #3
@@ -113,6 +132,27 @@ skip_swap:
         orreq  r3, r3, r10
 #endif
 
+        ldr     r8, param_h_offset
+        ldr     r9, param_sample_width
+        ands    r9, r9, #1
+        movne   r8, r8, lsl #1
+        addne   r8, r8, #1
+        str     r8, param_h_offset
+
+        ldr     r8, param_palette_control
+        cmp     r8, #2
+        movgt   r8, #2
+        mov     r8, r8, lsl #1
+        orr     r8, r8, r9
+        ldr     r9, param_capture_line
+        add     r9, r9, r8, lsl #2
+        ldr     r8, [r9]
+        str     r8, capture_address
+
+        ldr    r8, =sentinel
+        ldr    r9, =0x48444d49         // "HDMI" sentinel
+        str    r9, [r8]
+
 frame:
 
         bl     wait_for_vsync
@@ -122,16 +162,12 @@ frame:
         ldr    r8, =inBandPointer
         ldr    r9, =inBandData
         str    r9, [r8]
-        
-        ldr    r8, =sentinel
-        ldr    r9, =0x48444d49         // "HDMI" sentinel 
-        str    r9, [r8]
-        
-        ldr    r8, =paletteFlags        
+
+        ldr    r8, =paletteFlags
         ldr    r9, [r8]
         bic    r9, r9, #BIT_IN_BAND_DETECTED     //in band data detected
         str    r9, [r8]
- 
+
 
         // Working registers while frame is being captured
         //
@@ -281,14 +317,15 @@ skip_line_loop:
         subs   r5, r5, #1
         b      skip_line_loop
 skip_line_loop_exit:
-        
+
         push   {r1-r5, r11}
-        ldr    r12, param_capture_line
+
+        ldr    r12, capture_address
         sub    r12, r12, #4
         // Call preload capture line function (runs all paths of capture code to preload it into cache)
         blx    r12
         pop    {r1-r5, r11}
-        
+
         // Compute the current scanline mod 10
         ldr    r5, param_v_offset
         CLEAR_VSYNC
@@ -307,7 +344,7 @@ process_line_loop:
 
         // Preserve the state used by the outer code
         push   {r1-r5, r11}
- 
+
         ldr     r5, param_fb_height
         adrl    r0, paletteHighNibble
         ldr     r6, param_nlines
@@ -315,16 +352,16 @@ process_line_loop:
         subs    r6, r6, #VERTICAL_OFFSET
         movmi   r6, #0
         cmp     r6, #0x100
-        movge   r6, #0xff    
+        movge   r6, #0xff
         ldrb    r8, [r0, r6]
 
-        ldr     r6, =paletteFlags         
+        ldr     r6, =paletteFlags
         ldr     r9, [r6]
         bic     r9, r9, #0xf0000000
-        tst     r9, #BIT_MULTI_PALETTE 
-        orrne   r9, r9, r8, lsl#28   
+        tst     r9, #BIT_MULTI_PALETTE
+        orrne   r9, r9, r8, lsl#28
         str     r9, [r6]
-        
+
         // The capture line function is provided the following:
         //   r0 = pointer to current line in frame buffer
         //   r1 = number of complete psync cycles to capture (=param_chars_per_line)
@@ -336,20 +373,20 @@ process_line_loop:
         //   r7 = number of psyncs to skip
         //
         // All registers are available as scratch registers (i.e. nothing needs to be preserved)
-        
+
         // Setup parameters
         mov    r0, r11
         ldr    r6, linecountmod10
         ldr    r7, param_h_offset
-        // Load the address of the capture_line function into r10
-        ldr    r12, param_capture_line
+        // Load the address of the capture_line function into r12
+        ldr    r12, capture_address
         // Call capture line function
         blx    r12
 
         // Restore the state used by the outer code
 
         pop    {r1-r5, r11}
-        
+
         ldr    r7, param_fb_height
         cmp    r7, #DUPLICATE_HEIGHT
         // Skip a whole line to maintain aspect ratio
@@ -363,19 +400,19 @@ process_line_loop:
 
         subs   r5, r5, #1
         bne    process_line_loop
-        
+
         push   {r1-r5, r11}
-        
+
         ldr    r9, =paletteFlags
         ldr    r8, [r9]
         bic    r8, r8, #BIT_SET_MODE2_16COLOUR   // mode 2 emulation flag
-        bic    r8, r8, #BIT_MODE2_PALETTE 
+        bic    r8, r8, #BIT_MODE2_PALETTE
         mov    r9, #0           // palette changed flag
 
 
-        
+
         tst    r8, #BIT_IN_BAND_DETECTED
-        beq    noInBandData       
+        beq    noInBandData
 
         adr    r10, customPalette
         ldr    r12, =inBandData
@@ -385,39 +422,39 @@ process_line_loop:
         cmp    r11, #76        //sanity check on size
         bgt    noInBandData
         mov    r11, r11, lsr #1
-        ORR    r8, #BIT_SET_MODE2_16COLOUR          // mode 2 emulation enabled    
-        ORR    r8, #BIT_MODE2_PALETTE         
-commandloop:      
-        ldrb   r1, [r12], #1   //read 1 byte of command data  
+        ORR    r8, #BIT_SET_MODE2_16COLOUR          // mode 2 emulation enabled
+        ORR    r8, #BIT_MODE2_PALETTE
+commandloop:
+        ldrb   r1, [r12], #1   //read 1 byte of command data
         and    r0, r1, #0x0f
-        ldrb   r1, [r12], #1   //read 1 byte of command data   
+        ldrb   r1, [r12], #1   //read 1 byte of command data
         and    r3, r1, #0xf0
         orr    r0, r0, r3, lsl #4
         and    r3, r1, #0x0f
         orr    r0, r0, r3, lsl #16
         orr    r0, r0, r0, lsl #4
-               
+
         ldr    r2, [r10]
         str    r0, [r10], #4
-        
+
         cmp    r0, r2
         movne  r9, #1
 
         subs   r11, r11, #1
         bne    commandloop
-           
+
 noInBandData:
 
         ldr    r10, =paletteFlags
         ldr    r7, [r10]
         str    r8, [r10]
-        cmp    r9, #0    
+        cmp    r9, #0
         cmpeq  r7, r8
-        blne   osd_update_palette 
-        
+        blne   osd_update_palette
+
         pop    {r1-r5,r11}
-        
-        
+
+
         // Update the OSD in Mode 0..6
         pop    {r11}
         tst    r3, #BIT_MODE7
@@ -657,6 +694,7 @@ clear_loop:
         bne    clear_loop
         mov    pc, lr
 
+
 // ======================================================================
 // Local Variables
 // ======================================================================
@@ -717,6 +755,15 @@ param_ncapture:
 param_capture_line:
         .word 0
 
+param_palette_control:
+        .word 0
+
+param_sample_width:
+        .word 0
+
+capture_address:
+        .word 0
+
 linecountmod10:
         .word 0
 
@@ -730,13 +777,106 @@ lock_fail:
         .word 0
 
         .ltorg
-        
+
 customPalette:
         .space 1024, 0
 
 paletteHighNibble:
-        .space 1024, 0     
-  
+        .space 1024, 0
+
 dummyscreen:               // used by capture preload
         .space 8192, 0
-  
+
+
+capture_line_mode7_4bpp_table:
+        .word capture_line_mode7_4bpp
+        .word capture_line_mode7_4bpp
+        .word capture_line_mode7_4bpp
+        .word capture_line_mode7_4bpp
+        .word capture_line_mode7_4bpp
+        .word capture_line_mode7_4bpp
+
+capture_line_normal_4bpp_table:
+        .word capture_line_default_4bpp
+        .word capture_line_sixbits_4bpp
+        .word capture_line_inband_4bpp
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+        .word capture_line_default_4bpp // placeholder for ntsc artifacting
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+
+capture_line_odd_4bpp_table:
+capture_line_even_4bpp_table:
+        .word capture_line_oddeven_4bpp
+        .word capture_line_sixbits_4bpp // placeholder for six bits
+        .word capture_line_oddeven_4bpp // placeholder for in band
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+        .word capture_line_oddeven_4bpp // placeholder for ntsc artifacting
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+
+capture_line_double_4bpp_table:
+        .word capture_line_double_4bpp
+        .word capture_line_sixbits_4bpp // placeholder for six bits
+        .word capture_line_double_4bpp  // placeholder for in band
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+        .word capture_line_double_4bpp  // placeholder for ntsc artifacting
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+
+capture_line_half_odd_4bpp_table:
+capture_line_half_even_4bpp_table:
+        .word capture_line_half_4bpp
+        .word capture_line_sixbits_4bpp // placeholder for six bits
+        .word capture_line_half_4bpp // placeholder for in band
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+        .word capture_line_half_4bpp // placeholder for ntsc artifacting
+        .word capture_line_sixbits_4bpp // placeholder for in band six bits
+
+
+capture_line_normal_8bpp_table:
+        .word capture_line_default_8bpp
+        .word capture_line_sixbits_8bpp
+        .word capture_line_inband_8bpp
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+        .word capture_line_default_8bpp // placeholder for ntsc artifacting
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+
+capture_line_odd_8bpp_table:
+capture_line_even_8bpp_table:
+        .word capture_line_oddeven_8bpp
+        .word capture_line_sixbits_8bpp // placeholder for six bits
+        .word capture_line_oddeven_8bpp // placeholder for in band
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+        .word capture_line_oddeven_8bpp // placeholder for ntsc artifacting
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+
+capture_line_double_8bpp_table:
+        .word capture_line_double_8bpp
+        .word capture_line_sixbits_8bpp // placeholder for six bits
+        .word capture_line_double_8bpp  // placeholder for in band
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+        .word capture_line_double_8bpp  // placeholder for ntsc artifacting
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+
+capture_line_half_odd_8bpp_table:
+capture_line_half_even_8bpp_table:
+        .word capture_line_half_8bpp
+        .word capture_line_sixbits_8bpp // placeholder for six bits
+        .word capture_line_half_8bpp    // placeholder for in band
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+        .word capture_line_half_8bpp    // placeholder for ntsc artifacting
+        .word capture_line_sixbits_8bpp // placeholder for in band six bits
+
+capture_line_atom_4bpp_table:
+        .word capture_line_atom_4bpp;
+        .word capture_line_atom_4bpp;
+        .word capture_line_atom_4bpp;
+        .word capture_line_atom_4bpp;
+        .word capture_line_atom_4bpp;
+        .word capture_line_atom_4bpp;
+
+capture_line_atom_8bpp_table:
+        .word capture_line_atom_8bpp;
+        .word capture_line_atom_8bpp;
+        .word capture_line_atom_8bpp;
+        .word capture_line_atom_8bpp;
+        .word capture_line_atom_8bpp;
+        .word capture_line_atom_8bpp;

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -19,121 +19,6 @@
 .global paletteHighNibble
 .global dummyscreen
 
-// ======================================================================
-// Macros
-// ======================================================================
-
-// Data Synchronisation Barrier
-.macro DSB
-        mcr    p15, 0, r0, c7, c10, 4
-.endm
-
-// Data Memory Barrier
-.macro DMB
-        mcr    p15, 0, r0, c7, c10, 5
-.endm
-
-.macro READ_CYCLE_COUNTER reg
-#if defined(RPI2) || defined(RPI3)
-        mrc    p15, 0, \reg, c9, c13, 0
-#else
-        mrc    p15, 0, \reg, c15, c12, 1
-#endif
-.endm
-
-.macro CLEAR_VSYNC
-        // Clear the VSYNC interrupt
-        ldr    r0, =SMICTRL
-        bic    r3, r3, #BIT_VSYNC_MARKER
-        mov    r7, #0
-        str    r7, [r0]
-        // Don't proceed until this write is complete
-        DSB
-.endm
-
-.macro SHOW_VSYNC
-        bic    r3, r3, #BIT_VSYNC_MARKER
-        tst    r3, #(BIT_PROBE)
-        bne    novsync\@
-        // Poll for the VSYNC interrupt
-        ldr    r0, =INTPEND2
-        ldr    r0, [r0]
-        tst    r0, #(1<<VSYNCINT)
-        beq    novsync\@
-        // Clear the VSYNC interrupt
-        CLEAR_VSYNC
-        // If the vsync indicator is enabled, mark the next line in red
-        tst    r3, #(BIT_VSYNC)
-        orrne  r3, r3, #BIT_VSYNC_MARKER
-        // Remember the line where vsync occurred
-        str    r5, vsync_line
-novsync\@:
-.endm
-
-#ifdef MULTI_BUFFER
-.macro FLIP_BUFFER
-        // Skip the multi buffering in mode 7 and probe mode
-        tst    r3, #(BIT_MODE7 | BIT_PROBE)
-        bne    noflip\@
-        // Flip to the last completed draw buffer
-        // It seems the GPU delays this until the next vsync
-        push   {r0-r3}
-        mov    r14, r3, lsr #OFFSET_LAST_BUFFER
-        and    r0, r14, #3
-        bl     swapBuffer
-        pop    {r0-r3}
-noflip\@:
-.endm
-#endif
-
-.macro WAIT_FOR_CSYNC_0
-wait\@:
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
-        bne    wait\@
-        // Check again in case of noise
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
-        bne    wait\@
-.endm
-
-.macro WAIT_FOR_CSYNC_1
-wait\@:
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
-        beq    wait\@
-        // Check again in case of noise
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
-        beq    wait\@
-.endm
-
-.macro KEY_PRESS_DETECT mask, ret, counter
-        ldr    r5, \counter    // Load the counter value
-        tst    r8, #\mask      // Is the button pressed (active low)?
-        movne  r5, #0          // Clear the counter
-        addeq  r5, r5, #1      // If pressed, then increment the counter valye
-        str    r5, \counter    // And always write back the counter value
-
-        cmp    r5, #1          // Counter goes from 0->1 when key initially
-        orreq  r0, #\ret       // Indicate the initial press in the result
-
-        cmp    r5, #32         // 32 = auto repeat delay
-        tstge  r5, #7          // 7  = auto repeat rate
-        orreq  r0, #\ret       // Indicate the auto repeated press in the result
-
-        cmp    r5, #128        // 128 = auto repeat delay
-        tstge  r5, #3          // 3 = auto repeat rate
-        orreq  r0, #\ret       // Indicate the auto repeated press in the result
-
-        cmp    r5, #256        // 256 = auto repeat delay
-        tstge  r5, #1          // 1 = auto repeat rate
-        orreq  r0, #\ret       // Indicate the auto repeated press in the result
-.endm
-
-
 
 
 rgb_to_fb:
@@ -232,7 +117,7 @@ frame:
 
         bl     wait_for_vsync
         ldr    r0, default_vsync_line
-        str    r0, vsync_line      // default for vsync line if vsync in blanking area
+        str    r0, vsync_line          // default for vsync line if vsync in blanking area
 
         ldr    r8, =inBandPointer
         ldr    r9, =inBandData
@@ -388,9 +273,7 @@ skip_mode_test:
 fixupmodes:
         tst    r3, #BIT_FIELD_TYPE
         subne  r5, r5, #1     // Modes 0-6 + 7
-        cmp    r5, #0
-        subne  r5, r5, #1       // 1 less CSYNC as additional CSYNC after cache preload
-        skip_line_loop:
+skip_line_loop:
         cmp    r5, #0
         ble    skip_line_loop_exit
         WAIT_FOR_CSYNC_0
@@ -399,21 +282,17 @@ fixupmodes:
         b      skip_line_loop
 skip_line_loop_exit:
         
-        push   {r0-r12}
-        orr    r3, #PSYNC_MASK 
-        ldr    r10, param_capture_line
-        sub    r10, r10, #4
+        push   {r1-r5, r11}
+        ldr    r12, param_capture_line
+        sub    r12, r12, #4
         // Call preload capture line function (runs all paths of capture code to preload it into cache)
-        blx    r10
-        pop    {r0-r12}
-
-        WAIT_FOR_CSYNC_0
-        WAIT_FOR_CSYNC_1
+        blx    r12
+        pop    {r1-r5, r11}
         
         // Compute the current scanline mod 10
         ldr    r5, param_v_offset
         CLEAR_VSYNC
-        add    r5, r5, #1
+        add    r5, r5, #2
 mod10:
         subs   r5, r5, #10
         bpl    mod10
@@ -428,30 +307,6 @@ process_line_loop:
 
         // Preserve the state used by the outer code
         push   {r1-r5, r11}
-
-        // Wait for the start of hsync
-        WAIT_FOR_CSYNC_0
-        READ_CYCLE_COUNTER r10
-
-        // Wait for the end of hsync
-        WAIT_FOR_CSYNC_1
-        READ_CYCLE_COUNTER r6
-
-        // Calculate length of low hsync pulse (in ARM cycles = ns)
-        sub    r10, r6, r10
-        
-        // Start with the configured horizontal offset
-        ldr    r7, param_h_offset
-
-        // Implement half character horizontal scrolling:
-        // - a "short"  hsync is 3.5us, leave h_offset as-is
-        // - a "normal" hsync is 4.0us, increment h_offset by 1
-        // - a "long"   hsync is 4.5us, increment h_offset by 2
-        // So test against two thresholds inbetween these values
-        cmp    r10, #(4000 + 224)
-        addgt  r7, r7, #1
-        cmp    r10, #(4000 - 224)
-        addgt  r7, r7, #1
  
         ldr     r5, param_fb_height
         adrl    r0, paletteHighNibble
@@ -463,7 +318,7 @@ process_line_loop:
         movge   r6, #0xff    
         ldrb    r8, [r0, r6]
 
-        ldr     r6, =paletteFlags        
+        ldr     r6, =paletteFlags         
         ldr     r9, [r6]
         bic     r9, r9, #0xf0000000
         tst     r9, #BIT_MULTI_PALETTE 
@@ -485,10 +340,11 @@ process_line_loop:
         // Setup parameters
         mov    r0, r11
         ldr    r6, linecountmod10
+        ldr    r7, param_h_offset
         // Load the address of the capture_line function into r10
-        ldr    r10, param_capture_line
+        ldr    r12, param_capture_line
         // Call capture line function
-        blx    r10
+        blx    r12
 
         // Restore the state used by the outer code
 

--- a/src/rgb_to_fb.h
+++ b/src/rgb_to_fb.h
@@ -17,35 +17,21 @@ extern int sw2counter;
 
 extern int sw3counter;
 
-extern int capture_line_atom_4bpp();
-
-extern int capture_line_atom_8bpp();
-
-extern int capture_line_inband_4bpp();
-
-extern int capture_line_inband_8bpp();
-
-extern int capture_line_default_4bpp();
-
-extern int capture_line_default_8bpp();
-
-extern int capture_line_oddeven_4bpp();
-
-extern int capture_line_oddeven_8bpp();
-
-extern int capture_line_half_4bpp();
-
-extern int capture_line_half_8bpp();
-
-extern int capture_line_double_4bpp();
-
-extern int capture_line_double_8bpp();
-
-extern int capture_line_sixbits_4bpp();
-
-extern int capture_line_sixbits_8bpp();
-
-extern int capture_line_mode7_4bpp();
+extern int capture_line_mode7_4bpp_table();
+extern int capture_line_normal_4bpp_table();
+extern int capture_line_odd_4bpp_table();
+extern int capture_line_even_4bpp_table();
+extern int capture_line_double_4bpp_table();
+extern int capture_line_half_odd_4bpp_table();
+extern int capture_line_half_even_4bpp_table();
+extern int capture_line_normal_8bpp_table();
+extern int capture_line_odd_8bpp_table();
+extern int capture_line_even_8bpp_table();
+extern int capture_line_double_8bpp_table();
+extern int capture_line_half_odd_8bpp_table();
+extern int capture_line_half_even_8bpp_table();
+extern int capture_line_atom_4bpp_table();
+extern int capture_line_atom_8bpp_table();
 
 extern int vsync_line;
 


### PR DESCRIPTION
Six bit sampling support integrated and new table driven mechanism for selecting the capture loop.
Six bit looks very stable now at 16Mhz so may well work with EGA.
Note H offset is automatically compensated when six bit switched on so there is no visible difference in the screen but things like in band and the odd/even/double pixel sampling won't work as there are no capture loops yet.
Alignment doesn't work in 8 bits/pixel mode as it assumes the buffer is 4 bits.
