### PR TITLE
Genlock improvements

### DIFF
--- a/src/osd.c
+++ b/src/osd.c
@@ -133,7 +133,7 @@ static param_t features[] = {
    {             F_MUX,        "Input Mux", 0,                    1, 1 },
    {           F_VSYNC,  "VSync Indicator", 0,                    1, 1 },
    {       F_VLOCKMODE,       "VLock Mode", 0,                    5, 1 },
-   {       F_VLOCKLINE,       "VLock Line", 5,                  265, 1 },
+   {       F_VLOCKLINE,       "VLock Line", 0,                  265, 1 },
 #ifdef MULTI_BUFFER
    {        F_NBUFFERS,      "Num Buffers", 0,                    3, 1 },
 #endif


### PR DESCRIPTION
Auto switch to double buffered mode if set to single buffered mode and not mode7 when the osd is put on the screen. This means the OSD is always visible even if the genlock bar is not in the optimal position.
As the OSD is always visible, the default of num buffers has been set to single to reduce lag and the vsync bar has been positioned at the top of the screen instead of the bottom to further reduce lag.
Also fixed a couple of issues caused by changing to the Double height geometry setting.

Lag can be tested using quest paint to compare the delay between moving the mouse and the actual movement of the cursor.


