### PR TITLE
Add sync timeout & fix scaling + OSD bugs

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -232,6 +232,9 @@ typedef struct {
 #define MAX_RESOLUTION 64
 #define MAX_RESOLUTION_WIDTH 32
 
+#define FRAME_TIMEOUT 24*1024*1024           // ~24ms which is over a frame / field @ 50Hz (20ms)
+#define LINE_TIMEOUT 74*1024                 // ~74uS
+
 // PLLH registers, from:
 // https://github.com/F5OEO/librpitx/blob/master/src/gpio.h
 

--- a/src/geometry.c
+++ b/src/geometry.c
@@ -255,7 +255,7 @@ void geometry_get_fb_params(capture_info_t *capinfo) {
    if (ratio > 1.34) {
        h_size43 = v_size * 4 / 3;
    }
-   if (ratio < 1.32) {
+   if (ratio < 1.24) {               // was 1.32 but don't correct 5:4 aspect ratio (1.25) to 4:3 as it does good integer scaling for 640x256 and 640x200
        v_size43 = h_size * 3 / 4;
    }
 

--- a/src/macros.S
+++ b/src/macros.S
@@ -1,5 +1,16 @@
+.macro  LINE_TIMEOUT_TEST
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #LINE_TIMEOUT
+.endm
+
+
 .macro WAIT_FOR_CSYNC_0
+        READ_CYCLE_COUNTER r14
 waitlo\@:
+        LINE_TIMEOUT_TEST
+        bgt    endlo\@
         // Read the GPLEV0
         ldr    r8, [r4]
         tst    r8, #CSYNC_MASK
@@ -10,10 +21,14 @@ waitlo\@:
         ldrne  r8, [r4]
         tstne  r8, #CSYNC_MASK
         bne    waitlo\@
+endlo\@:
 .endm
 
 .macro WAIT_FOR_CSYNC_1
+        READ_CYCLE_COUNTER r14
 waithi\@:
+        LINE_TIMEOUT_TEST
+        bgt    endhi\@
         // Read the GPLEV0
         ldr    r8, [r4]
         tst    r8, #CSYNC_MASK
@@ -25,39 +40,53 @@ waithi\@:
         eorne  r8, r8, #CSYNC_MASK
         tstne  r8, #CSYNC_MASK
         bne    waithi\@
+endhi\@:
 .endm
 
 .macro WAIT_FOR_CSYNC_0_R9
-waitlo\@:
+        READ_CYCLE_COUNTER r14
+waitlo9\@:
+        LINE_TIMEOUT_TEST
+        bgt    endlo9\@
         // Read the GPLEV0
         ldr    r8, [r4]
         cmp    r9, #0
         tstne  r8, #CSYNC_MASK
-        bne    waitlo\@
+        bne    waitlo9\@
 
         // Check again in case of noise
         cmp    r9, #0
         tstne  r3, #BIT_OLD_CPLDV1V2
         ldrne  r8, [r4]
         tstne  r8, #CSYNC_MASK
-        bne    waitlo\@
+        bne    waitlo9\@
+endlo9\@:
 .endm
 
 .macro WAIT_FOR_CSYNC_0_FAST_R9
+        READ_CYCLE_COUNTER r14
 waitloF\@:
+        LINE_TIMEOUT_TEST
+        bgt    endloF9\@
         // Read the GPLEV0
         ldr    r8, [r4]
         cmp    r9, #0
         tstne  r8, #CSYNC_MASK
         bne    waitloF\@
+endloF9\@:
 .endm
 
 .macro WAIT_FOR_CSYNC_1_FAST
+        READ_CYCLE_COUNTER r14
 waithiF\@:
+        LINE_TIMEOUT_TEST
+        bgt    endhiF\@
         // Read the GPLEV0
         ldr    r8, [r4]
+        eor    r8, r8, #CSYNC_MASK
         tst    r8, #CSYNC_MASK
-        beq    waithiF\@
+        bne    waithiF\@
+endhiF\@:
 .endm
 
 .macro  SWITCH_PSYNC_TO_VSYNC
@@ -110,7 +139,13 @@ waitPF\@:
 .endm
 
 .macro WAIT_FOR_PSYNC_EDGE_SLOW
+        READ_CYCLE_COUNTER r14
 waitPS\@:
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #FRAME_TIMEOUT
+        bgt    endPS\@
         // Read the GPLEV0
         ldr    r8, [r4]
         eor    r8, r3
@@ -131,6 +166,7 @@ waitPS\@:
 
         // toggle the polarity to look for the opposite edge next time
         eor    r8, r3    // restore r8 value
+endPS\@:
         eor    r3, #PSYNC_MASK
 .endm
 

--- a/src/macros.S
+++ b/src/macros.S
@@ -1,92 +1,65 @@
-.macro  LINE_TIMEOUT_TEST
+.macro LINE_TIMEOUT_TEST
         READ_CYCLE_COUNTER r8
         subs   r8, r8, r14
         rsbmi  r8, r8, #0
         cmp    r8, #LINE_TIMEOUT
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eorgt  r8, r8, #CSYNC_MASK        //inverting the value after the timeout will cause the test to pass
+        tst    r8, #CSYNC_MASK
 .endm
 
+.macro LINE_TIMEOUT_TEST_R9
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #LINE_TIMEOUT
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eorgt  r8, r8, #CSYNC_MASK        //inverting the value after the timeout will cause the test to pass
+        cmp    r9, #0
+        tstne  r8, #CSYNC_MASK
+.endm
 
 .macro WAIT_FOR_CSYNC_0
         READ_CYCLE_COUNTER r14
 waitlo\@:
         LINE_TIMEOUT_TEST
-        bgt    endlo\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
         bne    waitlo\@
+        LINE_TIMEOUT_TEST
+        bne    waitlo\@
+.endm
 
-        // Check again in case of noise
-        tst    r3, #BIT_OLD_CPLDV1V2
-        ldrne  r8, [r4]
-        tstne  r8, #CSYNC_MASK
-        bne    waitlo\@
-endlo\@:
+.macro WAIT_FOR_CSYNC_0_R9
+        READ_CYCLE_COUNTER r14
+waitlo9\@:
+        LINE_TIMEOUT_TEST_R9
+        bne    waitlo9\@
+        LINE_TIMEOUT_TEST_R9
+        bne    waitlo9\@
+.endm
+
+.macro WAIT_FOR_CSYNC_0_FAST_R9
+        READ_CYCLE_COUNTER r14
+waitloF\@:
+        LINE_TIMEOUT_TEST_R9
+        bne    waitloF\@
 .endm
 
 .macro WAIT_FOR_CSYNC_1
         READ_CYCLE_COUNTER r14
 waithi\@:
         LINE_TIMEOUT_TEST
-        bgt    endhi\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        tst    r8, #CSYNC_MASK
         beq    waithi\@
-        // Check again in case of noise
-
-        tst    r3, #BIT_OLD_CPLDV1V2
-        ldrne  r8, [r4]
-        eorne  r8, r8, #CSYNC_MASK
-        tstne  r8, #CSYNC_MASK
-        bne    waithi\@
-endhi\@:
-.endm
-
-.macro WAIT_FOR_CSYNC_0_R9
-        READ_CYCLE_COUNTER r14
-waitlo9\@:
         LINE_TIMEOUT_TEST
-        bgt    endlo9\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        cmp    r9, #0
-        tstne  r8, #CSYNC_MASK
-        bne    waitlo9\@
-
-        // Check again in case of noise
-        cmp    r9, #0
-        tstne  r3, #BIT_OLD_CPLDV1V2
-        ldrne  r8, [r4]
-        tstne  r8, #CSYNC_MASK
-        bne    waitlo9\@
-endlo9\@:
-.endm
-
-.macro WAIT_FOR_CSYNC_0_FAST_R9
-        READ_CYCLE_COUNTER r14
-waitloF\@:
-        LINE_TIMEOUT_TEST
-        bgt    endloF9\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        cmp    r9, #0
-        tstne  r8, #CSYNC_MASK
-        bne    waitloF\@
-endloF9\@:
+        beq    waithi\@
 .endm
 
 .macro WAIT_FOR_CSYNC_1_FAST
         READ_CYCLE_COUNTER r14
 waithiF\@:
         LINE_TIMEOUT_TEST
-        bgt    endhiF\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        eor    r8, r8, #CSYNC_MASK
-        tst    r8, #CSYNC_MASK
-        bne    waithiF\@
-endhiF\@:
+        beq    waithiF\@
 .endm
 
 .macro  SWITCH_PSYNC_TO_VSYNC
@@ -135,38 +108,6 @@ waitPF\@:
 
         // toggle the polarity to look for the opposite edge next time
         eor    r8, r3    // restore r8 value
-        eor    r3, #PSYNC_MASK
-.endm
-
-.macro WAIT_FOR_PSYNC_EDGE_SLOW
-        READ_CYCLE_COUNTER r14
-waitPS\@:
-        READ_CYCLE_COUNTER r8
-        subs   r8, r8, r14
-        rsbmi  r8, r8, #0
-        cmp    r8, #FRAME_TIMEOUT
-        bgt    endPS\@
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        eor    r8, r3
-        tst    r8, #PSYNC_MASK
-        bne    waitPS\@
-
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        eor    r8, r3
-        tst    r8, #PSYNC_MASK
-        bne    waitPS\@
-
-        // Read the GPLEV0
-        ldr    r8, [r4]
-        eor    r8, r3
-        tst    r8, #PSYNC_MASK
-        bne    waitPS\@
-
-        // toggle the polarity to look for the opposite edge next time
-        eor    r8, r3    // restore r8 value
-endPS\@:
         eor    r3, #PSYNC_MASK
 .endm
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -1626,7 +1626,6 @@ int autoswitch_detect(int one_line_time_ns, int lines_per_frame, int sync_type) 
 void osd_set(int line, int attr, char *text) {
    if (!active) {
       active = 1;
-      clear_menu_bits();
       osd_update_palette();
    }
    attributes[line] = attr;
@@ -1669,6 +1668,9 @@ int osd_key(int key) {
          osd_state = MENU;
          current_menu[depth] = &main_menu;
          current_item[depth] = 0;
+         if(active == 0) {
+            clear_menu_bits();
+         }
          redraw_menu();
       } else if (key == key_cal) {
 

--- a/src/osd.c
+++ b/src/osd.c
@@ -1626,6 +1626,7 @@ int autoswitch_detect(int one_line_time_ns, int lines_per_frame, int sync_type) 
 void osd_set(int line, int attr, char *text) {
    if (!active) {
       active = 1;
+      clear_menu_bits();
       osd_update_palette();
    }
    attributes[line] = attr;

--- a/src/osd.c
+++ b/src/osd.c
@@ -1205,7 +1205,7 @@ void osd_update_palette() {
          }
       } else {
 
-         if ((i > (num_colours >> 1)) && get_feature(F_SCANLINES)) {
+         if ((i >= (num_colours >> 1)) && get_feature(F_SCANLINES)) {
             int scanline_intensity = get_feature(F_SCANLINESINT) ;
             r = (r * scanline_intensity)>>4;
             g = (g * scanline_intensity)>>4;

--- a/src/osd.c
+++ b/src/osd.c
@@ -2125,13 +2125,11 @@ void osd_update(uint32_t *osd_base, int bytes_per_line) {
       return;
    }
    // SAA5050 character data is 12x20
-   int bufferCharWidth = geometry_get_value(FB_WIDTH) / 12;         // SAA5050 character data is 12x20
+   int bufferCharWidth = capinfo->width / 12;         // SAA5050 character data is 12x20
 
    uint32_t *line_ptr = osd_base;
    int words_per_line = bytes_per_line >> 2;
-   if ((geometry_get_value(FB_HEIGHTX2))
-       && (bufferCharWidth >= LINELEN)
-       && (geometry_get_value(FB_BPP) < 8 ) ) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
+   if (capinfo->heightx2 && (bufferCharWidth >= LINELEN) && (capinfo->bpp < 8)) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
       for (int line = 0; line < NLINES; line++) {
          int attr = attributes[line];
          int len = (attr & ATTR_DOUBLE_SIZE) ? (LINELEN >> 1) : LINELEN;
@@ -2306,14 +2304,12 @@ void osd_update_fast(uint32_t *osd_base, int bytes_per_line) {
       return;
    }
    // SAA5050 character data is 12x20
-   int bufferCharWidth = geometry_get_value(FB_WIDTH) / 12;         // SAA5050 character data is 12x20
+   int bufferCharWidth = capinfo->width / 12;         // SAA5050 character data is 12x20
 
    uint32_t *line_ptr = osd_base;
    int words_per_line = bytes_per_line >> 2;
 
-   if ((geometry_get_value(FB_HEIGHTX2))
-       && (bufferCharWidth >= LINELEN)
-       && (geometry_get_value(FB_BPP) < 8 ) ) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
+   if (capinfo->heightx2 && (bufferCharWidth >= LINELEN) && (capinfo->bpp < 8)) {       // if frame buffer is large enough and not 8bpp use SAA5050 font
       for (int line = 0; line < NLINES; line++) {
          int attr = attributes[line];
          int len = (attr & ATTR_DOUBLE_SIZE) ? (LINELEN >> 1) : LINELEN;

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -10,6 +10,7 @@
 .global key_press_reset
 .global measure_vsync
 .global analyse_sync
+.global clear_screen
 .global measure_n_lines
 .global sw1counter
 .global sw2counter
@@ -625,7 +626,7 @@ exit:
 #endif
         pop    {r4-r12, lr}
         mov    pc, lr
-        
+
 key_press_reset:
         push   {r4-r12, lr}
         ldr    r4, =GPLEV0
@@ -636,16 +637,15 @@ key_press_reset:
         tst    r8, #SW2_MASK
         addeq  r0, r0, #1
         tst    r8, #SW3_MASK
-        addeq  r0, r0, #1       
+        addeq  r0, r0, #1
         pop    {r4-r12, lr}
         mov     pc, lr
-        
+
 // ======================================================================
 // ANALYSE SYNC POLARITY
 // ======================================================================
 analyse_sync:
         push    {r4-r12, lr}
-
         SWITCH_PSYNC_TO_VSYNC
         ldr    r4, =GPLEV0
 
@@ -656,7 +656,7 @@ delaysloop:
         READ_CYCLE_COUNTER r11
         subs   r12, r10, r11
         rsbmi  r12, r12, #0
-        cmp    r12, #33554432                   // (2^25) = ~33ms which is over a frame / field @ 50Hz (20ms)
+        cmp    r12, #FRAME_TIMEOUT
         blt    delaysloop
 
         // 66ms test loop to pick up vsync (would be 20ms for 50Hz, 16.6ms for 60Hz)
@@ -676,7 +676,7 @@ analyse_vloop:
         READ_CYCLE_COUNTER r11
         subs   r12, r10, r11
         rsbmi  r12, r12, #0
-        cmp    r12, #33554432<<1                    // (2^25) = ~33ms which is over a frame / field @ 50Hz (20ms)
+        cmp    r12, #(FRAME_TIMEOUT << 1)
         blt    analyse_vloop
 
        // cmp    r8, #4                             // if a very small count in r8 or r9, it might be noise / spikes on vsync so set to 0
@@ -687,12 +687,12 @@ analyse_vloop:
         mov    r0, #0
         cmp    r6, r7                              // is low time > high time
         orrgt  r0, #SYNC_BIT_HSYNC_INVERTED        // inverted means positive going
+        cmp    r8, r9                              // is low time > high time
+        orrgt  r0, r0, #SYNC_BIT_VSYNC_INVERTED    // inverted means positive going
         cmp    r8, #0                              // is low count 0
         cmpne  r9, #0                              // if not is high count 0
         orreq  r0, r0, #SYNC_BIT_COMPOSITE_SYNC    // if one or other is zero then no vsync pulses
-        cmp    r8, r9                              // is low time > high time
-        orrgt  r0, r0, #SYNC_BIT_VSYNC_INVERTED    // inverted means positive going
-
+        biceq  r0, r0, #SYNC_BIT_VSYNC_INVERTED    // inverted vsync has no meaning with composite sync
         SWITCH_VSYNC_TO_PSYNC
 
         pop    {r4-r12, pc}
@@ -718,7 +718,7 @@ wait_for_vsync:
         // r8 = value read from GPLEV0
         // r9 = state variable (1 = seen a long pulse
 
-
+        push   {lr}
         ldr    r10, param_detected_sync_type
         tst    r10, #SYNC_BIT_MIXED_SYNC           //clear if V and H not eored in CPLD
         tsteq  r10, #SYNC_BIT_COMPOSITE_SYNC       //clear if separate H and V syncs
@@ -727,8 +727,14 @@ wait_for_vsync:
         // Initialize "seen long pulse" to false (0)
         mov    r9, #0
         // Wait for csync to be high
+        READ_CYCLE_COUNTER r10
         WAIT_FOR_CSYNC_1
 vsync_loop:
+        READ_CYCLE_COUNTER r8
+        subs    r8, r8, r10
+        rsbmi   r8, r8, #0
+        cmp     r8, #FRAME_TIMEOUT
+        bgt     abort_vsync
         // Wait for the falling edge of csync
         WAIT_FOR_CSYNC_0
         // Record time of the falling edge
@@ -757,13 +763,13 @@ seen_short:
         cmp    r9, #1
         // No, so look back for the next pulse
         bne    vsync_loop
-
+abort_vsync:
         ldr    r8, last_vsync_time
         str    r6, last_vsync_time
         subs   r8, r6, r8
         rsbmi  r8, r8, #0
         str    r8, vsync_period
-        mov    pc, lr
+        pop    {pc}
 
 separate_syncs:
         SWITCH_PSYNC_TO_VSYNC
@@ -785,7 +791,7 @@ separate_syncs:
         rsbmi  r8, r8, #0
         str    r8, vsync_period
         WAIT_FOR_CSYNC_1                        // make sure clear of any hsync pulse
-        mov    pc, lr
+        pop    {pc}
 
 // ======================================================================
 // MEASURE_VSYNC
@@ -871,12 +877,12 @@ measure_n_loop:
 // ======================================================================
 
 clear_screen:
+        push   {r4-r12, lr}
         ldr    r5, param_fb_height
         ldr    r6, param_fb_pitch
         ldr    r11, param_framebuffer0
         ldr    r8, =0x88888888
         mul    r6, r5, r6
-
 #ifdef MULTI_BUFFER
         mov    r5, #NBUFFERS
         mul    r6, r5, r6
@@ -890,12 +896,12 @@ clear_loop:
         and    r7, r8
         str    r7, [r11], #4
         bne    clear_loop
-        mov    pc, lr
+        pop    {r4-r12, pc}
 clearnot7:
         subs   r6, r6, #4
         str    r7, [r11], #4
         bne    clearnot7
-        mov    pc, lr
+        pop    {r4-r12, pc}
 
 // ======================================================================
 // Local Variables

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -10,7 +10,8 @@
 .global key_press_reset
 .global measure_vsync
 .global analyse_sync
-.global clear_screen
+.global clear_full_screen
+.global clear_menu_bits
 .global measure_n_lines
 .global sw1counter
 .global sw2counter
@@ -877,7 +878,6 @@ measure_n_loop:
 // ======================================================================
 
 clear_screen:
-        push   {r4-r12, lr}
         ldr    r5, param_fb_height
         ldr    r6, param_fb_pitch
         ldr    r11, param_framebuffer0
@@ -901,6 +901,53 @@ clearnot7:
         subs   r6, r6, #4
         str    r7, [r11], #4
         bne    clearnot7
+        mov    pc, lr
+
+// ======================================================================
+// CLEAR_FULL_SCREEN
+// ======================================================================
+
+clear_full_screen:
+        push   {r4-r12, lr}
+        ldr    r5, param_fb_height
+        ldr    r6, param_fb_pitch
+        ldr    r11, param_framebuffer0
+        mul    r6, r5, r6
+#ifdef MULTI_BUFFER
+        mov    r5, #NBUFFERS
+        mul    r6, r5, r6
+#endif
+        mov    r7, #0
+clearfull:
+        subs   r6, r6, #4
+        str    r7, [r11], #4
+        bne    clearfull
+        pop    {r4-r12, pc}
+// ======================================================================
+// CLEAR_MENU_BITS
+// ======================================================================
+
+clear_menu_bits:
+        push   {r4-r12, lr}
+        ldr    r5, param_fb_height
+        ldr    r6, param_fb_pitch
+        ldr    r7, param_fb_bpp
+        ldr    r11, param_framebuffer0
+        ldr    r8, =0x88888888
+        ldr    r9, =0x80808080
+        cmp    r7, #0
+        movne  r8, r9
+        mul    r6, r5, r6
+#ifdef MULTI_BUFFER
+        mov    r5, #NBUFFERS
+        mul    r6, r5, r6
+#endif
+clear_menu:
+        ldr    r7, [r11]
+        subs   r6, r6, #4
+        bic    r7, r8
+        str    r7, [r11], #4
+        bne    clear_menu
         pop    {r4-r12, pc}
 
 // ======================================================================

--- a/src/rgb_to_fb.S
+++ b/src/rgb_to_fb.S
@@ -650,7 +650,6 @@ analyse_sync:
         SWITCH_PSYNC_TO_VSYNC
         ldr    r4, =GPLEV0
 
-        // 33ms delay to allow any sync change to settle
         READ_CYCLE_COUNTER r10
 delaysloop:
         ldr    r5, [r4]                            // dummy read for delay
@@ -660,7 +659,6 @@ delaysloop:
         cmp    r12, #FRAME_TIMEOUT
         blt    delaysloop
 
-        // 66ms test loop to pick up vsync (would be 20ms for 50Hz, 16.6ms for 60Hz)
         mov    r6, #0 //csync low
         mov    r7, #0 //csync high
         mov    r8, #0 //vsync low
@@ -775,15 +773,63 @@ abort_vsync:
 separate_syncs:
         SWITCH_PSYNC_TO_VSYNC
         ldr    r8, [r4]                         //delay
+        ldr    r9, [r4]                         //delay
         tst    r10, #SYNC_BIT_VSYNC_INVERTED    // if set then +ve going vsync
         biceq  r3, r3, #PSYNC_MASK
         orrne  r3, r3, #PSYNC_MASK
+        READ_CYCLE_COUNTER r14
+waitPSA:
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #FRAME_TIMEOUT
+        eorgt  r3, #PSYNC_MASK                  //inverting selection forces tests to exit
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSA
 
-        WAIT_FOR_PSYNC_EDGE_SLOW                // wait for vsync active
-        WAIT_FOR_PSYNC_EDGE_SLOW                // wait for end of vsync
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSA
+
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSA
+
+        eor    r3, #PSYNC_MASK
+
+waitPSB:
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #FRAME_TIMEOUT
+        eorgt  r3, #PSYNC_MASK                  //inverting selection forces tests to exit
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSB
+
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSB
+
+        // Read the GPLEV0
+        ldr    r8, [r4]
+        eor    r8, r3
+        tst    r8, #PSYNC_MASK
+        bne    waitPSB
+
         READ_CYCLE_COUNTER r6
         mov    r7, r6                           // make all fields look the same
-
         SWITCH_VSYNC_TO_PSYNC
 
         ldr    r8, last_vsync_time
@@ -791,7 +837,15 @@ separate_syncs:
         subs   r8, r6, r8
         rsbmi  r8, r8, #0
         str    r8, vsync_period
-        WAIT_FOR_CSYNC_1                        // make sure clear of any hsync pulse
+
+        READ_CYCLE_COUNTER r14
+waitglitch:
+        READ_CYCLE_COUNTER r8
+        subs   r8, r8, r14
+        rsbmi  r8, r8, #0
+        cmp    r8, #1024                        // wait 1uS to avoid any glitches as Vsync and Hsync not co-timed
+        blt    waitglitch
+        WAIT_FOR_CSYNC_1                          // resync with hsync
         pop    {pc}
 
 // ======================================================================

--- a/src/rgb_to_fb.h
+++ b/src/rgb_to_fb.h
@@ -13,6 +13,8 @@ extern int measure_vsync();
 
 extern int analyse_sync();
 
+extern int clear_screen();
+
 extern int measure_n_lines(int n);
 
 extern int sw1counter;

--- a/src/rgb_to_fb.h
+++ b/src/rgb_to_fb.h
@@ -13,7 +13,9 @@ extern int measure_vsync();
 
 extern int analyse_sync();
 
-extern int clear_screen();
+extern int clear_full_screen();
+
+extern int clear_menu_bits();
 
 extern int measure_n_lines(int n);
 

--- a/src/rgb_to_hdmi.c
+++ b/src/rgb_to_hdmi.c
@@ -1743,7 +1743,7 @@ void rgb_to_hdmi_main() {
 
       } while (!mode_changed && !fb_size_changed);
       osd_clear();
-      clear_screen();
+      clear_full_screen();
    }
 }
 

--- a/src/rgb_to_hdmi.c
+++ b/src/rgb_to_hdmi.c
@@ -1522,6 +1522,9 @@ void setup_profile() {
     cpld->set_mode(mode7);
     log_debug("Done loading sample points");
 
+    capinfo->detected_sync_type = cpld->analyse();
+    log_info("Detected polarity state = %s (%s)", sync_names[capinfo->detected_sync_type & SYNC_BIT_MASK], mixed_names[(capinfo->detected_sync_type & SYNC_BIT_MIXED_SYNC) ? 1 : 0]);
+
     geometry_get_fb_params(capinfo);
 
     cpld->update_capture_info(capinfo);
@@ -1569,6 +1572,7 @@ void rgb_to_hdmi_main() {
    capinfo = &default_capinfo;
    capinfo->v_adjust = 0;
    capinfo->h_adjust = 0;
+   cpld->set_mode(0);
    // Determine initial sync polarity (and correct whether inversion required or not)
    capinfo->detected_sync_type = cpld->analyse();
    log_info("Detected polarity state at startup = %s (%s)", sync_names[capinfo->detected_sync_type & SYNC_BIT_MASK], mixed_names[(capinfo->detected_sync_type & SYNC_BIT_MIXED_SYNC) ? 1 : 0]);
@@ -1590,9 +1594,6 @@ void rgb_to_hdmi_main() {
 
    while (1) {
       log_info("-----------------------LOOP------------------------");
-
-      capinfo->detected_sync_type = cpld->analyse();
-      log_info("Detected polarity state = %s (%s)", sync_names[capinfo->detected_sync_type & SYNC_BIT_MASK], mixed_names[(capinfo->detected_sync_type & SYNC_BIT_MIXED_SYNC) ? 1 : 0]);
 
       setup_profile();
 


### PR DESCRIPTION
There is now a sync timeout on both H and V sync which allows the ZX80 to work properly with the screen blanking when no sync is generated. Also it fixes a problem on the PC where the Pi hung up when the Pi and PC were powered at the same time. (The Pi detected the wrong sort of V sync at startup and then hung waiting for pulses that never arrived)
There are also various bug fixes.
BTW I sent out a few boards to PC testers so maybe we should think about getting a release ready and updating the documentation.