### PR TITLE
Add support for line doubled capture with improved integer scaling

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -558,10 +558,11 @@ typedef struct {
 #define  VSYNC_POLARITY                6
 #define  NUM_VSYNC                     7
 
-#define  VIDEO_PROGRESSIVE 0
-#define  VIDEO_INTERLACED  1
-#define  VIDEO_TELETEXT    2
-#define  NUM_VIDEO         3
+#define  VIDEO_PROGRESSIVE   0
+#define  VIDEO_INTERLACED    1
+#define  VIDEO_TELETEXT      2
+#define  VIDEO_LINE_DOUBLED  3
+#define  NUM_VIDEO           4
 
 #define  SAMPLE_WIDTH_1    0
 #define  SAMPLE_WIDTH_3    1

--- a/src/geometry.c
+++ b/src/geometry.c
@@ -54,7 +54,8 @@ static const char *fb_sizex2_names[] = {
 static const char *deint_names[] = {
    "Progressive",
    "Interlaced",
-   "Interlaced Teletext"
+   "Interlaced Teletext",
+   "Line Doubled"
 };
 
 static const char *bpp_names[] = {
@@ -68,9 +69,9 @@ static param_t params[] = {
    {    H_OFFSET,           "H Offset",           "h_offset",         1,        384, 4 },
    {    V_OFFSET,           "V Offset",           "v_offset",         0,        256, 1 },
    { MIN_H_WIDTH,        "Min H Width",        "min_h_width",       150,       1920, 8 },
-   {MIN_V_HEIGHT,       "Min V Height",       "min_v_height",       150,       1200, 2 },
+   {MIN_V_HEIGHT,       "Min V Height",       "min_v_height",       100,       1200, 2 },
    { MAX_H_WIDTH,        "Max H Width",        "max_h_width",       200,       1920, 8 },
-   {MAX_V_HEIGHT,       "Max V Height",       "max_v_height",       200,       1200, 2 },
+   {MAX_V_HEIGHT,       "Max V Height",       "max_v_height",       120,       1200, 2 },
    {    H_ASPECT,     "H Pixel Aspect",           "h_aspect",         0,          8, 1 },
    {    V_ASPECT,     "V Pixel Aspect",           "v_aspect",         0,          8, 1 },
    {   FB_SIZEX2,            "FB Size",            "fb_size",         0,          3, 1 },
@@ -427,6 +428,10 @@ void geometry_get_fb_params(capture_info_t *capinfo) {
     capinfo->autoswitch     = get_autoswitch();
     capinfo->timingset      = modeset;
     capinfo->sync_edge      = cpld->get_sync_edge();
+
+    if (capinfo->video_type == VIDEO_LINE_DOUBLED) {
+        capinfo->video_type = VIDEO_PROGRESSIVE;
+    }
 
     capinfo->sizex2 = geometry->fb_sizex2;
     switch(geometry->fb_bpp) {
@@ -903,6 +908,12 @@ void geometry_get_fb_params(capture_info_t *capinfo) {
     //log_info("Final aspect2: %dx%d, %dx%d, %dx%d", h_aspect, v_aspect, hscale, vscale, caphscale, capvscale);
     calculate_cpu_timings();
     //log_info("size= %d, %d, %d, %d, %d, %d, %d",capinfo->chars_per_line, capinfo->nlines, geometry_min_h_width, geometry_min_v_height,capinfo->width,  capinfo->height, capinfo->sizex2);
+
+    if (geometry->video_type == VIDEO_LINE_DOUBLED && (capinfo->sizex2 & SIZEX2_DOUBLE_HEIGHT) != 0) {
+        capinfo->nlines <<= 1;
+        capinfo->sizex2 &= SIZEX2_DOUBLE_WIDTH;
+    }
+
 }
 
 int get_hscale() {

--- a/src/rgb_to_hdmi.c
+++ b/src/rgb_to_hdmi.c
@@ -474,6 +474,9 @@ int height = 0;
             }
         }
         int height = capinfo->height >> (capinfo->sizex2 & SIZEX2_DOUBLE_HEIGHT);
+        if (geometry_get_value(VIDEO_TYPE) == VIDEO_LINE_DOUBLED) {
+            height >>= 1;
+        }
         int vscale = v_size / height;
         v_overscan = v_size - (vscale * height);
         adj_v_overscan = v_overscan;


### PR DESCRIPTION
These changes allow capture of line doubled sources with half integer scaling values e.g. 2.50

To use
Set the vertical min and max height to half of the required value e.g. for 480 lines set them to 240
Set FB Size to Double Height or Double Height+Width depending on how your width is setup
Set Video Type to "Line Doubled" (this setting is ignored if Double Height is not enabled)

After this the scaling is calculated using the above settings but the capture actually works as if min & max height are double the displayed value (e.g. 480 for a 240 displayed value) with FB Size Double Height disabled

Note this has no effect on horizontal. e.g. To get similar results for 640, use half the pixel clock rate and 320 pixels with Double Width enabled.
